### PR TITLE
Add Iglu Server Helm Chart

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Version 0.1.5 (2022-04-15)
+--------------------------
+Add self as repository in CI (#20)
+Add chart for Snowplow Iglu Server v0.8.3 (#14)
+
 Version 0.1.4 (2022-04-15)
 --------------------------
 Remove ct install from workflow as certain charts are not compatible (#13)

--- a/charts/snowplow-iglu-server/Chart.lock
+++ b/charts/snowplow-iglu-server/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: dockerconfigjson
+  repository: https://snowplow-devops.github.io/helm-charts
+  version: 0.1.0
+- name: cloudserviceaccount
+  repository: https://snowplow-devops.github.io/helm-charts
+  version: 0.1.0
+digest: sha256:92127ad4fb4b1721b3a51927e4e199bb40ae8d26f0c85369b672845bf061ddaf
+generated: "2022-04-15T11:17:27.274533+02:00"

--- a/charts/snowplow-iglu-server/Chart.yaml
+++ b/charts/snowplow-iglu-server/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: snowplow-iglu-server
+description: A Helm Chart to deploy the Snowplow Iglu Server project
+version: 0.1.0
+appVersion: "0.8.3"
+icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
+home: https://github.com/snowplow-devops/helm-charts
+sources:
+  - https://github.com/snowplow-devops/helm-charts
+  - https://github.com/snowplow-incubator/iglu-server
+maintainers:
+  - name: jbeemster
+    url: https://github.com/jbeemster
+    email: jbeemster@users.noreply.github.com
+keywords:
+  - snowplow
+  - iglu
+  - schemas
+dependencies:
+  - name: dockerconfigjson
+    version: 0.1.0
+    repository: "https://snowplow-devops.github.io/helm-charts"
+  - name: cloudserviceaccount
+    version: 0.1.0
+    repository: "https://snowplow-devops.github.io/helm-charts"

--- a/charts/snowplow-iglu-server/README.md
+++ b/charts/snowplow-iglu-server/README.md
@@ -1,0 +1,188 @@
+# snowplow-iglu-server
+
+A helm chart for [Snowplow Iglu Server](https://github.com/snowplow-incubator/iglu-server).
+
+## TL;DR
+
+```bash
+helm repo add snowplow-devops https://snowplow-devops.github.io/helm-charts
+helm install snowplow-iglu-server snowplow-devops/snowplow-iglu-server
+```
+
+## Introduction
+
+This chart deploys a Snowplow Iglu Server on a Kubernetes cluster using the Helm package manager.  For demonstration purposes the system is deployed with an "in-memory" database.  Configure a "postgres" backend for production use-cases.
+
+## Installing the Chart
+
+Install or upgrading the chart with default configuration:
+
+```bash
+helm upgrade --install snowplow-iglu-server snowplow-devops/snowplow-iglu-server
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `snowplow-iglu-server` release:
+
+```bash
+helm delete snowplow-iglu-server
+```
+
+## Deployment options
+
+The most common settings we expect users to leverage are exposed as inputs under the `service.config.*` key.
+
+If however you need to tune other settings you can also optionally provide a base64 encoded HOCON in the `service.config.hoconBase64`.  It is important to remember however that the settings being defined in the common settings will *always* take precedence over anything you define in the config.
+
+### Backend: Postgres
+
+1. Configure a PostgreSQL backend
+  - As an example you can use: https://artifacthub.io/packages/helm/bitnami/postgresql
+  - You will need the endpoint, username, password, port and database name
+2. Make a copy of `values-local.yaml.tmpl` and call it `values-local.yaml`
+3. Sub in the database values from step 1
+4. Run: `helm upgrade --install snowplow-iglu-server --values values-local.yaml .`
+  - Make sure to target the same namespace as your PostgresDB (assumption is `default`)
+
+You can then port-forward the deployment to access it from your host:
+
+```bash
+kubectl port-forward --namespace default svc/snowplow-iglu-server-iglu-app 8080:8080
+```
+
+_Note_: This assumes 8080 is available on your host and you have used the default bind port of 8080.
+
+You can then use the Iglu Server as normal leveraging the APIKey you generated earlier and `localhost:8080` as your endpoint (e.g. `curl http://localhost:8080/static/swagger-ui/index.html`).
+
+### GCP (GKE) settings
+
+#### NetworkEndpointGroup binding
+
+To manage the load balancer externally from the GKE cluster you can bind the deployment onto dynamically assigned Network Endpoint Groups (NEGs).
+
+1. Set the NEG name: `service.gcp.networkEndpointGroupName: <valid_value>`
+   - Will default to the Chart release name
+2. This will create Zonal NEGs in your account automatically (do not proceed until the NEGs appear - check your deployment events if this doesn't happen!)
+3. Create a Load Balancer as usual and map the NEGs created into your backend service (follow the `Create Load Balancer` flow in the GCP Console)
+
+*Note*: The HealthCheck you create should map to the same port you used for the service deployment.
+
+#### Backend: CloudSQL Postgres with proxy
+
+To ease deployment to a GKE cluster you can optionally leverage the built-in CloudSQL proxy - this will create a service deployment exposing your CloudSQL instance within your cluster.
+
+To take advantage of this you will need to bind a service-account to the deployment which, in Terraform, looks something like the following:
+
+```hcl
+resource "google_service_account" "snowplow_iglu_server" {
+  account_id   = "snowplow-iglu-server"
+  display_name = "Snowplow Iglu Server service account"
+}
+
+resource "google_service_account_iam_binding" "snowplow_iglu_server_sa_wiu_binding" {
+  role = "roles/iam.workloadIdentityUser"
+  members = [
+    "serviceAccount:<project>.svc.id.goog[default/snowplow-iglu-server]",
+    "serviceAccount:<project>.svc.id.goog[default/snowplow-iglu-server-cloudsqlproxy]"
+  ]
+  service_account_id = google_service_account.snowplow_iglu_server.id
+}
+
+resource "google_project_iam_member" "snowplow_iglu_server_sa_cloudsql_client" {
+  role   = "roles/cloudsql.client"
+  member = "serviceAccount:${google_service_account.snowplow_iglu_server.email}"
+}
+
+output "snowplow_iglu_server_sa_account_email" {
+  value = google_service_account.snowplow_iglu_server.email
+}
+```
+
+You can then use the resulting value as an input to `cloudserviceaccount.gcp.serviceAccount` which will allow the CloudSQL deployment to access the database.
+
+You will need to fill these targeted fields:
+
+- `global.cloud: "gcp"`
+- `service.gcp.deployProxy: true`
+- `service.gcp.proxy.port: <some_value>`
+- `service.gcp.proxy.project: <project>`
+- `service.gcp.proxy.region: <region>`
+- `service.gcp.proxy.instanceName: <db_instance_name>`
+- `cloudserviceaccount.deploy: true`
+- `cloudserviceaccount.name: <unique_name>`
+- `cloudserviceaccount.gcp.serviceAccount: <output_value_from_above>`
+
+*Note*: As the iglu deployment and setup hooks depend on this service it is normal to expect a few initial failures to occur - they should automatically resolve without intervention.
+
+### AWS (EKS) settings
+
+#### TargetGroup binding
+
+To manage the load balancer externally to the kubernetes cluster you can bind the deployment to an existing TargetGroup ARN.  Its important that the TargetGroup exist ahead of time and that you use the same port as you have used in your `values.yaml`. 
+
+*Note*: Before this will work you will need to install the `aws-load-balancer-controller-crds` and `aws-load-balancer-controller` charts into your EKS cluster.
+
+You will need to fill these targeted fields:
+
+- `global.cloud: "aws"`
+- `service.aws.targetGroupARN: "<target_group_arn>"`
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| global.cloud | string | `""` | Cloud specific bindings (options: aws, gcp) |
+| service.deploySetupHooks | bool | `true` | Whether to run the post-deploy setup hooks |
+| service.port | int | `8080` | Port to bind and expose the service on |
+| service.image.repository | string | `"snowplow/iglu-server"` |  |
+| service.image.tag | string | `"0.8.3"` |  |
+| service.image.isRepositoryPublic | bool | `true` | Whether the repository is public |
+| service.minReplicas | int | `1` |  |
+| service.maxReplicas | int | `4` |  |
+| service.targetCPUUtilizationPercentage | int | `75` |  |
+| service.terminationGracePeriodSeconds | int | `630` |  |
+| service.readinessProbe.initialDelaySeconds | int | `5` |  |
+| service.readinessProbe.periodSeconds | int | `5` |  |
+| service.readinessProbe.timeoutSeconds | int | `5` |  |
+| service.readinessProbe.failureThreshold | int | `3` |  |
+| service.readinessProbe.successThreshold | int | `2` |  |
+| service.resources.limits.cpu | string | `"746m"` |  |
+| service.resources.limits.memory | string | `"900Mi"` |  |
+| service.resources.requests.cpu | string | `"400m"` |  |
+| service.resources.requests.memory | string | `"512Mi"` |  |
+| service.config.secrets.superApiKey | string | `""` | Lowercase uuidv4 to use as admin apikey of the service (default: auto-generated) |
+| service.config.repoServer.maxConnections | int | `16384` |  |
+| service.config.repoServer.idleTimeout | string | `"65 seconds"` |  |
+| service.config.database.type | string | `"dummy"` | Can be either 'dummy' (in-memory) or 'postgres' |
+| service.config.database.host | string | `""` | Postgres database host |
+| service.config.database.port | int | `5432` | Postgres database port |
+| service.config.database.dbname | string | `""` | Postgres database name |
+| service.config.database.secrets.username | string | `""` |  |
+| service.config.database.secrets.password | string | `""` |  |
+| service.config.patchesAllowed | bool | `false` | Whether to allow schema patching |
+| service.config.hoconBase64 | string | `""` | Optional Base64 encoded config HOCON (note: will not override above settings) |
+| service.config.javaOpts | string | `""` | Optional JAVA_OPTS inputs for the deployed service |
+| service.aws.targetGroupARN | string | `""` | EC2 TargetGroup ARN to bind the service onto |
+| service.gcp.networkEndpointGroupName | string | `""` | Name of the Network Endpoint Group to bind onto |
+| service.gcp.deployProxy | bool | `false` | Whether to use CloudSQL Proxy (note: requires GCP service account to be attached) |
+| service.gcp.proxy.port | int | `38000` | Port to bind proxy onto |
+| service.gcp.proxy.project | string | `""` | Project where CloudSQL instance is deployed |
+| service.gcp.proxy.region | string | `""` | Region where CloudSQL instance is deployed |
+| service.gcp.proxy.instanceName | string | `""` | Name of the CloudSQL instance |
+| service.gcp.proxy.image.repository | string | `"gcr.io/cloudsql-docker/gce-proxy"` |  |
+| service.gcp.proxy.image.tag | string | `"1.11"` |  |
+| service.gcp.proxy.image.isRepositoryPublic | bool | `true` | Whether the repository is public |
+| service.gcp.proxy.resources.limits.cpu | string | `"100m"` |  |
+| service.gcp.proxy.resources.limits.memory | string | `"256Mi"` |  |
+| service.gcp.proxy.resources.requests.cpu | string | `"50m"` |  |
+| service.gcp.proxy.resources.requests.memory | string | `"128Mi"` |  |
+| cloudserviceaccount.deploy | bool | `false` | Whether to create a service-account |
+| cloudserviceaccount.name | string | `"snowplow-iglu-server-service-account"` | Name of the service-account to create |
+| cloudserviceaccount.aws.roleARN | string | `""` | IAM Role ARN to bind to the k8s service account |
+| cloudserviceaccount.gcp.serviceAccount | string | `""` | Service Account email to bind to the k8s service account |
+| dockerconfigjson.name | string | `"snowplow-iglu-server-dockerhub"` | Name of the secret to use for the private repository |
+| dockerconfigjson.username | string | `""` | Username for the private repository |
+| dockerconfigjson.password | string | `""` | Password for the private repository |
+| dockerconfigjson.server | string | `"https://index.docker.io/v1/"` | Repository server URL |
+| dockerconfigjson.email | string | `""` | Email address for user of the private repository |

--- a/charts/snowplow-iglu-server/templates/NOTES.txt
+++ b/charts/snowplow-iglu-server/templates/NOTES.txt
@@ -1,0 +1,22 @@
+{{- if eq (include "iglu.service.config.database.type" .) "dummy" }}
+----------------------------------------------------------------------------------------------------------------------------------------------------
+WARNING: Your Iglu Server is running with a "dummy" in-memory backend - this means data is ephemeral and your min/max number of pods is locked to 1.
+         Change to "postgres" to run in a production setting.
+----------------------------------------------------------------------------------------------------------------------------------------------------
+{{- end }}
+
+The Iglu Server can be accessed via port {{ .Values.service.port }} on the following DNS names from within your cluster:
+
+    {{ include "iglu.app.name" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+To connect to your server from outside the cluster execute the following commands:
+
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "iglu.app.name" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+
+You can test the API options direction by visiting the Swagger URL in your browser at:
+
+    http://localhost:{{ .Values.service.port }}/static/swagger-ui/index.html
+
+To get the Super API Key run (if you did not set one yourself):
+
+    export IGLU_SUPER_API_KEY=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "iglu.app.secret.name" . }} -o jsonpath="{.data.CONFIG_FORCE_iglu_superApiKey}" | base64 --decode)

--- a/charts/snowplow-iglu-server/templates/_helpers.tpl
+++ b/charts/snowplow-iglu-server/templates/_helpers.tpl
@@ -1,0 +1,57 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Define a common name prefix for all created objects.
+*/}}
+{{- define "iglu.prefix" -}}
+{{ .Release.Name }}-iglu
+{{- end -}}
+
+{{/*
+Define resource names for the CloudSQL proxy service.
+*/}}
+{{- define "iglu.cloudsqlproxy.name" -}}
+{{ include "iglu.prefix" . }}-cloudsqlproxy
+{{- end -}}
+{{- define "iglu.cloudsqlproxy.host" -}}
+{{ include "iglu.cloudsqlproxy.name" . }}.{{ .Release.Namespace }}.svc.cluster.local
+{{- end -}}
+
+{{/*
+Define the name of the setup hooks.
+*/}}
+{{- define "iglu.hooks.name" -}}
+{{ include "iglu.prefix" . }}-hooks
+{{- end -}}
+
+{{/*
+Define resource names for the Iglu service.
+*/}}
+{{- define "iglu.app.name" -}}
+{{ include "iglu.prefix" . }}-app
+{{- end -}}
+{{- define "iglu.app.secret.name" -}}
+{{ include "iglu.prefix" . }}-secret
+{{- end -}}
+{{- define "iglu.app.config.name" -}}
+{{ include "iglu.prefix" . }}-config
+{{- end -}}
+
+{{/*
+Define default values for required values.
+*/}}
+{{- define "iglu.service.config.superApiKey" -}}
+{{- default uuidv4 .Values.service.config.secrets.superApiKey | lower -}}
+{{- end -}}
+{{- define "iglu.service.config.database.type" -}}
+{{- default "dummy" .Values.service.config.database.type | lower -}}
+{{- end -}}
+{{- define "iglu.service.targetCPUUtilizationPercentage" -}}
+{{- mul .Values.service.targetCPUUtilizationPercentage .Values.service.minReplicas }}
+{{- end -}}
+{{- define "iglu.service.gcp.networkEndpointGroupName" -}}
+{{- default .Release.Name .Values.service.gcp.networkEndpointGroupName -}}
+{{- end -}}
+{{- define "iglu.service.config.checksum" -}}
+{{- printf "%s-%s-%s" (include "iglu.service.config.superApiKey" .) .Values.service.config.database.secrets.password .Values.service.config.database.secrets.username | sha256sum -}}
+{{- end -}}

--- a/charts/snowplow-iglu-server/templates/cloudsqlproxy-deployment.yaml
+++ b/charts/snowplow-iglu-server/templates/cloudsqlproxy-deployment.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.service.gcp.deployProxy }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "iglu.cloudsqlproxy.name" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "iglu.cloudsqlproxy.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "iglu.cloudsqlproxy.name" . }}
+    spec:
+      {{- if .Values.cloudserviceaccount.deploy }}
+      serviceAccountName: {{ .Values.cloudserviceaccount.name }}
+      {{- end }}
+      automountServiceAccountToken: true
+      terminationGracePeriodSeconds: {{ .Values.service.terminationGracePeriodSeconds }}
+
+      {{- if not .Values.service.gcp.proxy.image.isRepositoryPublic }}
+      imagePullSecrets:
+      - name: {{ .Values.dockerconfigjson.name }}
+      {{- end }}
+
+      containers:
+      - name: {{ include "iglu.cloudsqlproxy.name" . }}
+        image: {{ .Values.service.gcp.proxy.image.repository}}:{{ .Values.service.gcp.proxy.image.tag}}
+        imagePullPolicy: Always
+
+        command:
+        - "/cloud_sql_proxy"
+        - "-instances={{ .Values.service.gcp.proxy.project }}:{{ .Values.service.gcp.proxy.region }}:{{ .Values.service.gcp.proxy.instanceName }}=tcp:0.0.0.0:{{ .Values.service.config.database.port }}"
+
+        resources:
+          {{- toYaml .Values.service.gcp.proxy.resources | nindent 10 }}
+{{- end }}

--- a/charts/snowplow-iglu-server/templates/cloudsqlproxy-service.yaml
+++ b/charts/snowplow-iglu-server/templates/cloudsqlproxy-service.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.service.gcp.deployProxy }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "iglu.cloudsqlproxy.name" . }}
+spec:
+  type: NodePort
+  selector:
+    app: {{ include "iglu.cloudsqlproxy.name" . }}
+  ports:
+  - port: {{ .Values.service.gcp.proxy.port }}
+    protocol: TCP
+    targetPort: {{ .Values.service.config.database.port }}
+{{- end }}

--- a/charts/snowplow-iglu-server/templates/iglu-deployment.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-deployment.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "iglu.app.name" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "iglu.app.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "iglu.app.name" . }}
+      annotations:
+        checksum/config: "{{ include "iglu.service.config.checksum" . }}"
+        {{- if ne .Values.service.config.hoconBase64 "" }}
+        checksum/config.hocon: "{{ .Values.service.config.hoconBase64 | sha256sum}}"
+        {{- end }}
+    spec:
+      {{- if .Values.cloudserviceaccount.deploy }}
+      serviceAccountName: {{ .Values.cloudserviceaccount.name }}
+      {{- end }}
+      automountServiceAccountToken: true
+      terminationGracePeriodSeconds: {{ .Values.service.terminationGracePeriodSeconds }}
+
+      {{- if not .Values.service.image.isRepositoryPublic }}
+      imagePullSecrets:
+      - name: {{ .Values.dockerconfigjson.name }}
+      {{- end }}
+
+      volumes:
+      {{- if ne .Values.service.config.hoconBase64 "" }}
+      - configMap:
+          name: {{ include "iglu.app.config.name" . }}
+          optional: false
+        name: {{ include "iglu.app.config.name" . }}-volume
+      {{- end }}
+
+      containers:
+      - name: {{ include "iglu.app.name" . }}
+        image: {{ .Values.service.image.repository}}:{{ .Values.service.image.tag}}
+        imagePullPolicy: Always
+
+        args:
+        - "-Dconfig.override_with_env_vars=true"
+        {{- if ne .Values.service.config.hoconBase64 "" }}
+        - "--config"
+        - "/etc/config/config.hocon"
+        {{- end }}
+
+        ports:
+        - containerPort: {{ .Values.service.port }}
+          protocol: TCP
+
+        env:
+        - name : "CONFIG_FORCE_iglu_repoServer_port"
+          value: "{{ .Values.service.port }}"
+        - name : "CONFIG_FORCE_iglu_repoServer_maxConnections"
+          value: "{{ .Values.service.config.repoServer.maxConnections }}"
+        - name : "CONFIG_FORCE_iglu_repoServer_idleTimeout"
+          value: "{{ .Values.service.config.repoServer.idleTimeout }}"
+        - name : "CONFIG_FORCE_iglu_database_type"
+          value: "{{ include "iglu.service.config.database.type" . }}"
+        {{- if .Values.service.gcp.deployProxy }}
+        - name : "CONFIG_FORCE_iglu_database_host"
+          value: {{ include "iglu.cloudsqlproxy.host" . }}
+        - name : "CONFIG_FORCE_iglu_database_port"
+          value: "{{ .Values.service.gcp.proxy.port }}"
+        {{- else }}
+        - name : "CONFIG_FORCE_iglu_database_host"
+          value: "{{ .Values.service.config.database.host }}"
+        - name : "CONFIG_FORCE_iglu_database_port"
+          value: "{{ .Values.service.config.database.port }}"
+        {{- end }}
+        - name : "CONFIG_FORCE_iglu_database_dbname"
+          value: "{{ .Values.service.config.database.dbname }}"
+        - name : "CONFIG_FORCE_iglu_patchesAllowed"
+          value: "{{ .Values.service.config.patchesAllowed }}"
+        {{- if not (empty .Values.service.config.javaOpts) }}
+        - name : "JAVA_OPTS"
+          value: "{{ .Values.service.config.javaOpts }}"
+        {{- end }}
+
+        envFrom:
+        - secretRef:
+            name: {{ include "iglu.app.secret.name" . }}
+
+        readinessProbe:
+          httpGet:
+            path: /api/meta/health
+            port: {{ .Values.service.port }}
+            scheme: HTTP
+          initialDelaySeconds: {{ .Values.service.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.service.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.service.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.service.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.service.readinessProbe.successThreshold }}
+
+        resources:
+          {{- toYaml .Values.service.resources | nindent 10 }}
+
+        volumeMounts:
+        {{- if ne .Values.service.config.hoconBase64 "" }}
+        - mountPath: /etc/config
+          mountPropagation: None
+          name: {{ include "iglu.app.config.name" . }}-volume
+        {{- end }}

--- a/charts/snowplow-iglu-server/templates/iglu-hoconconfigmap.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-hoconconfigmap.yaml
@@ -1,0 +1,8 @@
+{{- if ne .Values.service.config.hoconBase64 "" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "iglu.app.config.name" . }}
+binaryData:
+  config.hocon: {{ .Values.service.config.hoconBase64 }}
+{{- end }}

--- a/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.service.deploySetupHooks }}
+{{- if eq (include "iglu.service.config.database.type" .) "postgres" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "iglu.hooks.name" . }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+spec:
+  template:
+    metadata:
+      name: {{ include "iglu.hooks.name" . }}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: {{ include "iglu.hooks.name" . }}
+        image: {{ .Values.service.image.repository}}:{{ .Values.service.image.tag}}
+        imagePullPolicy: Always
+
+        args:
+        - "-Dconfig.override_with_env_vars=true"
+        - "setup"
+
+        env:
+        {{- if .Values.service.gcp.deployProxy }}
+        - name : "CONFIG_FORCE_iglu_database_host"
+          value: {{ include "iglu.cloudsqlproxy.host" . }}
+        - name : "CONFIG_FORCE_iglu_database_port"
+          value: "{{ .Values.service.gcp.proxy.port }}"
+        {{- else }}
+        - name : "CONFIG_FORCE_iglu_database_host"
+          value: "{{ .Values.service.config.database.host }}"
+        - name : "CONFIG_FORCE_iglu_database_port"
+          value: "{{ .Values.service.config.database.port }}"
+        {{- end }}
+        - name : "CONFIG_FORCE_iglu_database_dbname"
+          value: "{{ .Values.service.config.database.dbname }}"
+
+        envFrom:
+        - secretRef:
+            name: {{ include "iglu.app.secret.name" . }}
+{{- end }}
+{{- end }}

--- a/charts/snowplow-iglu-server/templates/iglu-hpa.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "iglu.app.name" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "iglu.app.name" . }}
+  {{- if eq (include "iglu.service.config.database.type" .) "postgres" }}
+  minReplicas: {{ .Values.service.minReplicas }}
+  maxReplicas: {{ .Values.service.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ include "iglu.service.targetCPUUtilizationPercentage" . }}
+  {{- else }}
+  minReplicas: 1
+  maxReplicas: 1
+  targetCPUUtilizationPercentage: 75
+  {{- end }}

--- a/charts/snowplow-iglu-server/templates/iglu-secret.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "iglu.app.secret.name" . }}
+type: Opaque
+data:
+  CONFIG_FORCE_iglu_superApiKey: "{{ include "iglu.service.config.superApiKey" . | b64enc }}"
+  CONFIG_FORCE_iglu_database_password: "{{ .Values.service.config.database.secrets.password | b64enc }}"
+  CONFIG_FORCE_iglu_database_username: "{{ .Values.service.config.database.secrets.username | b64enc }}"

--- a/charts/snowplow-iglu-server/templates/iglu-service.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "iglu.app.name" . }}
+  {{- if eq .Values.global.cloud "gcp" }}
+  annotations:
+    cloud.google.com/app-protocols:  '{"http-port": "HTTP"}'
+    cloud.google.com/neg: '{"exposed_ports": {"{{ .Values.service.port }}":{"name": "{{ include "iglu.service.gcp.networkEndpointGroupName" . }}"}}}'
+  {{- end }}
+spec:
+  type: NodePort
+  selector:
+    app: {{ include "iglu.app.name" . }}
+  ports:
+  - name: http-port
+    port: {{ .Values.service.port }}
+    protocol: TCP
+    targetPort: {{ .Values.service.port }}

--- a/charts/snowplow-iglu-server/templates/iglu-targetgroupbinding.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-targetgroupbinding.yaml
@@ -1,0 +1,11 @@
+{{- if eq .Values.global.cloud "aws" }}
+apiVersion: elbv2.k8s.aws/v1beta1
+kind: TargetGroupBinding
+metadata:
+  name: {{ include "iglu.app.name" . }}
+spec:
+  serviceRef:
+    name: {{ include "iglu.app.name" . }}
+    port: {{ .Values.service.port }}
+  targetGroupARN: {{ .Values.service.aws.targetGroupARN }}
+{{- end }}

--- a/charts/snowplow-iglu-server/values-aws.yaml.tmpl
+++ b/charts/snowplow-iglu-server/values-aws.yaml.tmpl
@@ -1,0 +1,32 @@
+global:
+  cloud: "aws"
+
+service:
+  deploySetupHooks: true
+  port: 8080
+  image:
+    repository: "snowplow/iglu-server"
+    tag: "0.8.3"
+  minReplicas: 1
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 75
+  terminationGracePeriodSeconds: 630
+
+  config:
+    secrets:
+      superApiKey: "<uuidv4>"
+    repoServer:
+      maxConnections: 16384
+      idleTimeout: "65 seconds"
+    database:
+      type: "postgres"
+      host: "<host>" 
+      port: 5432
+      dbname: "postgres"
+      secrets:
+        username: "postgres"
+        password: "<password>"
+    patchesAllowed: false
+
+  aws:
+    targetGroupARN: "<target-group-arn>"

--- a/charts/snowplow-iglu-server/values-gcp.yaml.tmpl
+++ b/charts/snowplow-iglu-server/values-gcp.yaml.tmpl
@@ -1,0 +1,46 @@
+global:
+  cloud: "gcp"
+
+service:
+  deploySetupHooks: true
+  port: 8080
+  image:
+    repository: "snowplow/iglu-server"
+    tag: "0.8.3"
+  minReplicas: 1
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 75
+  terminationGracePeriodSeconds: 630
+
+  config:
+    secrets:
+      superApiKey: "<uuidv4>"
+    repoServer:
+      maxConnections: 16384
+      idleTimeout: "65 seconds"
+    database:
+      type: "postgres"
+      port: 5432
+      dbname: "postgres"
+      secrets:
+        username: "postgres"
+        password: "<password>"
+    patchesAllowed: false
+
+  gcp:
+    networkEndpointGroupName: "<network-endpoint-group-name>"
+    deployProxy: true
+    proxy:
+      port: 38000
+      project: "<project>"
+      region: "<region>"
+      instanceName: "<cloudsql-instance-name>"
+      image:
+        repository: "gcr.io/cloudsql-docker/gce-proxy"
+        tag: "1.11"
+
+cloudserviceaccount:
+  deploy: true
+  name: "snowplow-iglu-server"
+  gcp:
+    serviceAccount: "<service-account-email>"

--- a/charts/snowplow-iglu-server/values-local.yaml.tmpl
+++ b/charts/snowplow-iglu-server/values-local.yaml.tmpl
@@ -1,0 +1,26 @@
+service:
+  deploySetupHooks: true
+  port: 8080
+  image:
+    repository: "snowplow/iglu-server"
+    tag: "0.8.3"
+  minReplicas: 1
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 75
+  terminationGracePeriodSeconds: 630
+
+  config:
+    secrets:
+      superApiKey: "<uuidv4>"
+    repoServer:
+      maxConnections: 16384
+      idleTimeout: "65 seconds"
+    database:
+      type: "postgres"
+      host: "<host>" 
+      port: 5432
+      dbname: "postgres"
+      secrets:
+        username: "postgres"
+        password: "<password>"
+    patchesAllowed: false

--- a/charts/snowplow-iglu-server/values.yaml
+++ b/charts/snowplow-iglu-server/values.yaml
@@ -1,0 +1,119 @@
+global:
+  # -- Cloud specific bindings (options: aws, gcp)
+  cloud: ""
+
+service:
+  # -- Whether to run the post-deploy setup hooks
+  deploySetupHooks: true
+
+  # -- Port to bind and expose the service on
+  port: 8080
+  image:
+    repository: "snowplow/iglu-server"
+    tag: "0.8.3"
+    # -- Whether the repository is public
+    isRepositoryPublic: true
+  minReplicas: 1
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 75
+  terminationGracePeriodSeconds: 630
+
+  readinessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 2
+
+  resources:
+    limits:
+      cpu: 746m
+      memory: 900Mi
+    requests:
+      cpu: 400m
+      memory: 512Mi
+
+  config:
+    secrets:
+      # -- Lowercase uuidv4 to use as admin apikey of the service (default: auto-generated)
+      superApiKey: ""
+    repoServer:
+      maxConnections: 16384
+      idleTimeout: "65 seconds"
+    database:
+      # -- Can be either 'dummy' (in-memory) or 'postgres'
+      type: "dummy"
+      # -- Postgres database host
+      host: ""
+      # -- Postgres database port
+      port: 5432
+      # -- Postgres database name
+      dbname: ""
+      secrets:
+        username: ""
+        password: ""
+    # -- Whether to allow schema patching
+    patchesAllowed: false
+
+    # -- Optional Base64 encoded config HOCON (note: will not override above settings)
+    hoconBase64: ""
+    # -- Optional JAVA_OPTS inputs for the deployed service
+    javaOpts: ""
+
+  aws:
+    # -- EC2 TargetGroup ARN to bind the service onto
+    targetGroupARN: ""
+
+  gcp:
+    # -- Name of the Network Endpoint Group to bind onto
+    networkEndpointGroupName: ""
+
+    # -- Whether to use CloudSQL Proxy (note: requires GCP service account to be attached)
+    deployProxy: false
+
+    proxy:
+      # -- Port to bind proxy onto
+      port: 38000
+      # -- Project where CloudSQL instance is deployed
+      project: ""
+      # -- Region where CloudSQL instance is deployed
+      region: ""
+      # -- Name of the CloudSQL instance
+      instanceName: ""
+      image:
+        repository: "gcr.io/cloudsql-docker/gce-proxy"
+        tag: "1.11"
+        # -- Whether the repository is public
+        isRepositoryPublic: true
+
+      resources:
+        limits:
+          cpu: 100m
+          memory: 256Mi
+        requests:
+          cpu: 50m
+          memory: 128Mi
+
+cloudserviceaccount:
+  # -- Whether to create a service-account
+  deploy: false
+  # -- Name of the service-account to create
+  name: "snowplow-iglu-server-service-account"
+  aws:
+    # -- IAM Role ARN to bind to the k8s service account
+    roleARN: ""
+  gcp:
+    # -- Service Account email to bind to the k8s service account
+    serviceAccount: ""
+
+dockerconfigjson:
+  # -- Name of the secret to use for the private repository
+  name: "snowplow-iglu-server-dockerhub"
+  # -- Username for the private repository
+  username: ""
+  # -- Password for the private repository
+  password: ""
+  # -- Repository server URL
+  server: "https://index.docker.io/v1/"
+  # -- Email address for user of the private repository
+  email: ""


### PR DESCRIPTION
This PR adds a Helm Chart for deploying a Snowplow Iglu Server.  Currently it supports being deployed on-premise with a local Postgres Database as well in both AWS + GCP.

It supports being exposed to the internet only via TargetGroup Bindings and Network Endpoint Groups - there are no ingress rules to allow this chart to create dedicated external cloud load balancers currently (internally this is how we deploy all of our services to allow easier management of the public facing system).

There is nothing to stop someone from binding the deployed service to an ingress controller however if they want to,

---

Tested locally with Docker Desktop, AWS & GCP.