### PR TITLE
charts/cron-job: Add chart to manage cron jobs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.9 (2022-07-17)
+--------------------------
+charts/cron-job: Add chart for installing a cron-job (#27)
+
 Version 0.1.8 (2022-06-17)
 --------------------------
 Add ct install action to workflow (#24)

--- a/charts/cron-job/Chart.lock
+++ b/charts/cron-job/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: dockerconfigjson
+  repository: https://snowplow-devops.github.io/helm-charts
+  version: 0.1.0
+digest: sha256:0331e8c24df90336f42414abdee3042503e6bf6a5e007a13c464164adf1624aa
+generated: "2022-07-17T15:47:05.549968+01:00"

--- a/charts/cron-job/Chart.yaml
+++ b/charts/cron-job/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: cron-job
+description: A Helm Chart to deploy an arbitrary container as a cron job.
+version: 0.1.0
+icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
+home: https://github.com/snowplow-devops/helm-charts
+sources:
+  - https://github.com/snowplow-devops/helm-charts
+maintainers:
+  - name: jbeemster
+    url: https://github.com/jbeemster
+    email: jbeemster@users.noreply.github.com
+keywords:
+  - cron
+dependencies:
+  - name: dockerconfigjson
+    version: 0.1.0
+    repository: "https://snowplow-devops.github.io/helm-charts"

--- a/charts/cron-job/README.md
+++ b/charts/cron-job/README.md
@@ -1,0 +1,53 @@
+# cron-job
+
+A helm chart to configure a cron job.
+
+## TL;DR
+
+```bash
+helm repo add snowplow-devops https://snowplow-devops.github.io/helm-charts
+helm install cron-job snowplow-devops/cron-job
+```
+
+## Introduction
+
+This chart creates a cron job of an arbitrary input container and input variables configured on the environment.
+
+## Installing the Chart
+
+Install or upgrading the chart with default configuration:
+
+```bash
+helm upgrade --install cron-job snowplow-devops/cron-job
+```
+
+_Note_: As default the chart simply deploys an example busybox to illustrate running a simple command - take note of the default `values.yaml` and alter to suit your needs!
+
+## Uninstalling the Chart
+
+To uninstall/delete the `cron-job` release:
+
+```bash
+helm delete cron-job
+```
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| job.schedule | string | `"*/1 * * * *"` |  |
+| job.concurrencyPolicy | string | `"Forbid"` |  |
+| job.failedJobsHistoryLimit | int | `1` |  |
+| job.successfulJobsHistoryLimit | int | `1` |  |
+| job.image.repository | string | `"busybox"` |  |
+| job.image.tag | string | `"latest"` |  |
+| job.image.isRepositoryPublic | bool | `true` | Whether the repository is public |
+| job.config.command | list | `[]` |  |
+| job.config.args | list | `[]` |  |
+| job.config.env | object | `{}` |  |
+| job.config.secrets | object | `{}` |  |
+| dockerconfigjson.name | string | `"snowplow-cron-job-dockerhub"` | Name of the secret to use for the private repository |
+| dockerconfigjson.username | string | `""` | Username for the private repository |
+| dockerconfigjson.password | string | `""` | Password for the private repository |
+| dockerconfigjson.server | string | `"https://index.docker.io/v1/"` | Repository server URL |
+| dockerconfigjson.email | string | `""` | Email address for user of the private repository |

--- a/charts/cron-job/templates/NOTES.txt
+++ b/charts/cron-job/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{ .Release.Name }} has been installed or updated.  Your job will now execute on the following schedule "{{ .Values.job.schedule }}".

--- a/charts/cron-job/templates/_helpers.tpl
+++ b/charts/cron-job/templates/_helpers.tpl
@@ -1,0 +1,18 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Define a common name prefix for all created objects.
+*/}}
+{{- define "job.prefix" -}}
+{{ .Release.Name }}-job
+{{- end -}}
+
+{{/*
+Define resource names.
+*/}}
+{{- define "job.app.name" -}}
+{{ include "job.prefix" . }}-app
+{{- end -}}
+{{- define "job.app.secret.name" -}}
+{{ include "job.prefix" . }}-secret
+{{- end -}}

--- a/charts/cron-job/templates/deployment.yaml
+++ b/charts/cron-job/templates/deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "job.app.name" . }}
+spec:
+  schedule: "{{ .Values.job.schedule }}"
+  concurrencyPolicy: "{{ .Values.job.concurrencyPolicy }}"
+  failedJobsHistoryLimit: {{ .Values.job.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ .Values.job.successfulJobsHistoryLimit }}
+
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: {{ include "job.app.name" . }}
+        spec:
+          automountServiceAccountToken: true
+
+          {{- if not .Values.job.image.isRepositoryPublic }}
+          imagePullSecrets:
+          - name: {{ .Values.dockerconfigjson.name }}
+          {{- end }}
+
+          restartPolicy: "Never"
+
+          containers:
+          - name: "{{ include "job.app.name" . }}"
+            image: "{{ .Values.job.image.repository }}:{{ .Values.job.image.tag }}"
+            imagePullPolicy: Always
+
+            {{- if .Values.job.config.command  }}
+            command:
+            {{- range $v := .Values.job.config.command }}
+            - "{{ $v }}"
+            {{- end }}
+            {{- end }}
+
+            {{- if .Values.job.config.args  }}
+            args:
+            {{- range $v := .Values.job.config.args }}
+            - "{{ $v }}"
+            {{- end }}
+            {{- end }}
+
+            {{- if .Values.job.config.env  }}
+            env:
+            {{- range $k, $v := .Values.job.config.env }}
+            - name: "{{ $k }}"
+              value: "{{ $v }}"
+            {{- end }}
+            {{- end }}
+            
+            {{- if .Values.job.config.secrets  }}
+            envFrom:
+            - secretRef:
+                name: {{ include "job.app.secret.name" . }}
+            {{- end }}

--- a/charts/cron-job/templates/secrets.yaml
+++ b/charts/cron-job/templates/secrets.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.job.config.secrets  }}
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "job.app.secret.name" . }}
+type: Opaque
+data:
+  {{- range $k, $v := .Values.job.config.secrets }}
+  {{ $k }}: "{{ $v | b64enc }}"
+  {{- end }}
+{{- end }}

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -1,0 +1,34 @@
+job:
+  schedule: "*/1 * * * *"
+  concurrencyPolicy: "Forbid"
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 1
+
+  image:
+    repository: "busybox"
+    tag: "latest"
+    # -- Whether the repository is public
+    isRepositoryPublic: true
+
+  config:
+    command: []
+    #  - "/bin/sh"
+    args: []
+    #  - "-c"
+    #  - "echo 'Environment $(hello_env)! Secret $(username).'"
+    env: {}
+    #  hello_env: "world"
+    secrets: {}
+    #  username: "password"
+
+dockerconfigjson:
+  # -- Name of the secret to use for the private repository
+  name: "snowplow-cron-job-dockerhub"
+  # -- Username for the private repository
+  username: ""
+  # -- Password for the private repository
+  password: ""
+  # -- Repository server URL
+  server: "https://index.docker.io/v1/"
+  # -- Email address for user of the private repository
+  email: ""


### PR DESCRIPTION
This adds a simple chart which can deploy an arbitrary image as a cron job to facilitate more easily deploying simple tasks to kubernetes.