### PR TITLE
Add support for service-accounts to Cron Job chart

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.10 (2022-07-22)
+---------------------------
+charts/cron-job: Add support for cloud service-accounts (#30)
+
 Version 0.1.9 (2022-07-17)
 --------------------------
 charts/cron-job: Add chart for installing a cron-job (#27)

--- a/charts/cron-job/Chart.lock
+++ b/charts/cron-job/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: dockerconfigjson
   repository: https://snowplow-devops.github.io/helm-charts
   version: 0.1.0
-digest: sha256:0331e8c24df90336f42414abdee3042503e6bf6a5e007a13c464164adf1624aa
-generated: "2022-07-17T15:47:05.549968+01:00"
+- name: cloudserviceaccount
+  repository: https://snowplow-devops.github.io/helm-charts
+  version: 0.1.0
+digest: sha256:92127ad4fb4b1721b3a51927e4e199bb40ae8d26f0c85369b672845bf061ddaf
+generated: "2022-07-22T16:15:36.614861+02:00"

--- a/charts/cron-job/Chart.yaml
+++ b/charts/cron-job/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cron-job
 description: A Helm Chart to deploy an arbitrary container as a cron job.
-version: 0.1.0
+version: 0.2.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:
@@ -14,5 +14,8 @@ keywords:
   - cron
 dependencies:
   - name: dockerconfigjson
+    version: 0.1.0
+    repository: "https://snowplow-devops.github.io/helm-charts"
+  - name: cloudserviceaccount
     version: 0.1.0
     repository: "https://snowplow-devops.github.io/helm-charts"

--- a/charts/cron-job/README.md
+++ b/charts/cron-job/README.md
@@ -35,6 +35,7 @@ helm delete cron-job
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| global.cloud | string | `""` | Cloud specific bindings (options: aws, gcp) |
 | job.schedule | string | `"*/1 * * * *"` |  |
 | job.concurrencyPolicy | string | `"Forbid"` |  |
 | job.failedJobsHistoryLimit | int | `1` |  |
@@ -51,3 +52,7 @@ helm delete cron-job
 | dockerconfigjson.password | string | `""` | Password for the private repository |
 | dockerconfigjson.server | string | `"https://index.docker.io/v1/"` | Repository server URL |
 | dockerconfigjson.email | string | `""` | Email address for user of the private repository |
+| cloudserviceaccount.deploy | bool | `false` | Whether to create a service-account |
+| cloudserviceaccount.name | string | `"snowplow-cron-job-service-account"` | Name of the service-account to create |
+| cloudserviceaccount.aws.roleARN | string | `""` | IAM Role ARN to bind to the k8s service account |
+| cloudserviceaccount.gcp.serviceAccount | string | `""` | Service Account email to bind to the k8s service account |

--- a/charts/cron-job/templates/deployment.yaml
+++ b/charts/cron-job/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
           labels:
             app: {{ include "job.app.name" . }}
         spec:
+          {{- if .Values.cloudserviceaccount.deploy }}
+          serviceAccountName: {{ .Values.cloudserviceaccount.name }}
+          {{- end }}
           automountServiceAccountToken: true
 
           {{- if not .Values.job.image.isRepositoryPublic }}

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -1,3 +1,7 @@
+global:
+  # -- Cloud specific bindings (options: aws, gcp)
+  cloud: ""
+
 job:
   schedule: "*/1 * * * *"
   concurrencyPolicy: "Forbid"
@@ -32,3 +36,15 @@ dockerconfigjson:
   server: "https://index.docker.io/v1/"
   # -- Email address for user of the private repository
   email: ""
+
+cloudserviceaccount:
+  # -- Whether to create a service-account
+  deploy: false
+  # -- Name of the service-account to create
+  name: "snowplow-cron-job-service-account"
+  aws:
+    # -- IAM Role ARN to bind to the k8s service account
+    roleARN: ""
+  gcp:
+    # -- Service Account email to bind to the k8s service account
+    serviceAccount: ""


### PR DESCRIPTION
This allows cloud IAM permissions to be bound to the cron-job being executed.