### PR TITLE
Creating Target Group Binding Chart for Mapping TG to K8s Service

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.17 (2022-08-24)
+---------------------------
+charts/aws-target-group-binding: Create chart (#47)
+
 Version 0.1.16 (2022-07-29)
 ---------------------------
 Make imagePullPolicy configurable in all charts (#43)

--- a/charts/aws-target-group-binding/Chart.yaml
+++ b/charts/aws-target-group-binding/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: aws-target-group-binding
+description: A Helm chart for deploying a TargetGroupBinding for use with the AWS LoadBalancer Controller
+type: application
+version: 0.1.0
+icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
+home: https://github.com/snowplow-devops/helm-charts
+sources:
+  - https://github.com/snowplow-devops/helm-charts
+maintainers:
+  - name: gthomson31
+    url: https://github.com/gthomson31
+    email: gthomson31@users.noreply.github.com
+keywords:
+  - kubernetes
+  - loadbalancer
+  - aws

--- a/charts/aws-target-group-binding/README.md
+++ b/charts/aws-target-group-binding/README.md
@@ -1,0 +1,48 @@
+# aws-target-group-binding
+
+A Helm chart for deploying a TargetGroupBinding resource for use with the AWS LoadBalancer Controller.
+
+## TL;DR
+
+```bash
+helm repo add snowplow-devops https://snowplow-devops.github.io/helm-charts
+helm install aws-target-group-binding snowplow-devops/aws-target-group-binding
+```
+
+## Introduction
+
+This chart will provision a TargetGroupBinding resource that can be combined with an externally provisioned AWS Loadbalancer to provide an ingress route into the defined kubernetes service.
+
+## Prerequisite
+
+In order to use this chart you will first require the aws-load-balancer-controller-crds to be installed, this can be done using the chart below.
+
+https://github.com/snowplow-devops/helm-charts/tree/main/charts/aws-load-balancer-controller-crds
+
+```bash
+helm upgrade --install aws-load-balancer-controller-crds --namespace kube-system snowplow-devops/aws-load-balancer-controller-crds
+```
+
+## Installing the Chart
+
+Install or upgrading the chart with default configuration:
+
+```bash
+helm upgrade --install aws-target-group-binding snowplow-devops/aws-target-group-binding
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `target-group-binding` release:
+
+```bash
+helm delete target-group-binding
+```
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| serviceName | string | `"myServiceName"` | Name of the service to add the binding against |
+| servicePort | int | `80` | The port the required service is running on |
+| targetGroupARN | string | `"arn:1234:5678"` | Amazon Resource Name (ARN) for the TargetGroup you want to use. |

--- a/charts/aws-target-group-binding/crds/elbv2.k8s.aws_targetgroupbindings.yaml
+++ b/charts/aws-target-group-binding/crds/elbv2.k8s.aws_targetgroupbindings.yaml
@@ -1,0 +1,333 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: targetgroupbindings.elbv2.k8s.aws
+spec:
+  group: elbv2.k8s.aws
+  names:
+    kind: TargetGroupBinding
+    listKind: TargetGroupBindingList
+    plural: targetgroupbindings
+    singular: targetgroupbinding
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Kubernetes Service's name
+      jsonPath: .spec.serviceRef.name
+      name: SERVICE-NAME
+      type: string
+    - description: The Kubernetes Service's port
+      jsonPath: .spec.serviceRef.port
+      name: SERVICE-PORT
+      type: string
+    - description: The AWS TargetGroup's TargetType
+      jsonPath: .spec.targetType
+      name: TARGET-TYPE
+      type: string
+    - description: The AWS TargetGroup's Amazon Resource Name
+      jsonPath: .spec.targetGroupARN
+      name: ARN
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TargetGroupBinding is the Schema for the TargetGroupBinding API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
+            properties:
+              networking:
+                description: networking provides the networking setup for ELBV2 LoadBalancer to access targets in TargetGroup.
+                properties:
+                  ingress:
+                    description: List of ingress rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                    items:
+                      properties:
+                        from:
+                          description: List of peers which should be able to access the targets in TargetGroup. At least one NetworkingPeer should be specified.
+                          items:
+                            description: NetworkingPeer defines the source/destination peer for networking rules.
+                            properties:
+                              ipBlock:
+                                description: IPBlock defines an IPBlock peer. If specified, none of the other fields can be set.
+                                properties:
+                                  cidr:
+                                    description: CIDR is the network CIDR. Both IPV4 or IPV6 CIDR are accepted.
+                                    type: string
+                                required:
+                                - cidr
+                                type: object
+                              securityGroup:
+                                description: SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.
+                                properties:
+                                  groupID:
+                                    description: GroupID is the EC2 SecurityGroupID.
+                                    type: string
+                                required:
+                                - groupID
+                                type: object
+                            type: object
+                          type: array
+                        ports:
+                          description: List of ports which should be made accessible on the targets in TargetGroup. If ports is empty or unspecified, it defaults to all ports with TCP.
+                          items:
+                            properties:
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: The port which traffic must match. When NodePort endpoints(instance TargetType) is used, this must be a numerical port. When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods. if port is unspecified, it defaults to all ports.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                description: The protocol which traffic must match. If protocol is unspecified, it defaults to TCP.
+                                enum:
+                                - TCP
+                                - UDP
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - from
+                      - ports
+                      type: object
+                    type: array
+                type: object
+              serviceRef:
+                description: serviceRef is a reference to a Kubernetes Service and ServicePort.
+                properties:
+                  name:
+                    description: Name is the name of the Service.
+                    type: string
+                  port:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Port is the port of the ServicePort.
+                    x-kubernetes-int-or-string: true
+                required:
+                - name
+                - port
+                type: object
+              targetGroupARN:
+                description: targetGroupARN is the Amazon Resource Name (ARN) for the TargetGroup.
+                type: string
+              targetType:
+                description: targetType is the TargetType of TargetGroup. If unspecified, it will be automatically inferred.
+                enum:
+                - instance
+                - ip
+                type: string
+            required:
+            - serviceRef
+            - targetGroupARN
+            type: object
+          status:
+            description: TargetGroupBindingStatus defines the observed state of TargetGroupBinding
+            properties:
+              observedGeneration:
+                description: The generation observed by the TargetGroupBinding controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The Kubernetes Service's name
+      jsonPath: .spec.serviceRef.name
+      name: SERVICE-NAME
+      type: string
+    - description: The Kubernetes Service's port
+      jsonPath: .spec.serviceRef.port
+      name: SERVICE-PORT
+      type: string
+    - description: The AWS TargetGroup's TargetType
+      jsonPath: .spec.targetType
+      name: TARGET-TYPE
+      type: string
+    - description: The AWS TargetGroup's Amazon Resource Name
+      jsonPath: .spec.targetGroupARN
+      name: ARN
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: TargetGroupBinding is the Schema for the TargetGroupBinding API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
+            properties:
+              ipAddressType:
+                description: ipAddressType specifies whether the target group is of type IPv4 or IPv6. If unspecified, it will be automatically inferred.
+                enum:
+                - ipv4
+                - ipv6
+                type: string
+              networking:
+                description: networking defines the networking rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                properties:
+                  ingress:
+                    description: List of ingress rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                    items:
+                      description: NetworkingIngressRule defines a particular set of traffic that is allowed to access TargetGroup's targets.
+                      properties:
+                        from:
+                          description: List of peers which should be able to access the targets in TargetGroup. At least one NetworkingPeer should be specified.
+                          items:
+                            description: NetworkingPeer defines the source/destination peer for networking rules.
+                            properties:
+                              ipBlock:
+                                description: IPBlock defines an IPBlock peer. If specified, none of the other fields can be set.
+                                properties:
+                                  cidr:
+                                    description: CIDR is the network CIDR. Both IPV4 or IPV6 CIDR are accepted.
+                                    type: string
+                                required:
+                                - cidr
+                                type: object
+                              securityGroup:
+                                description: SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.
+                                properties:
+                                  groupID:
+                                    description: GroupID is the EC2 SecurityGroupID.
+                                    type: string
+                                required:
+                                - groupID
+                                type: object
+                            type: object
+                          type: array
+                        ports:
+                          description: List of ports which should be made accessible on the targets in TargetGroup. If ports is empty or unspecified, it defaults to all ports with TCP.
+                          items:
+                            description: NetworkingPort defines the port and protocol for networking rules.
+                            properties:
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: The port which traffic must match. When NodePort endpoints(instance TargetType) is used, this must be a numerical port. When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods. if port is unspecified, it defaults to all ports.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                description: The protocol which traffic must match. If protocol is unspecified, it defaults to TCP.
+                                enum:
+                                - TCP
+                                - UDP
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - from
+                      - ports
+                      type: object
+                    type: array
+                type: object
+              nodeSelector:
+                description: node selector for instance type target groups to only register certain nodes
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              serviceRef:
+                description: serviceRef is a reference to a Kubernetes Service and ServicePort.
+                properties:
+                  name:
+                    description: Name is the name of the Service.
+                    type: string
+                  port:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Port is the port of the ServicePort.
+                    x-kubernetes-int-or-string: true
+                required:
+                - name
+                - port
+                type: object
+              targetGroupARN:
+                description: targetGroupARN is the Amazon Resource Name (ARN) for the TargetGroup.
+                minLength: 1
+                type: string
+              targetType:
+                description: targetType is the TargetType of TargetGroup. If unspecified, it will be automatically inferred.
+                enum:
+                - instance
+                - ip
+                type: string
+            required:
+            - serviceRef
+            - targetGroupARN
+            type: object
+          status:
+            description: TargetGroupBindingStatus defines the observed state of TargetGroupBinding
+            properties:
+              observedGeneration:
+                description: The generation observed by the TargetGroupBinding controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/aws-target-group-binding/templates/targetGroupBinding.yml
+++ b/charts/aws-target-group-binding/templates/targetGroupBinding.yml
@@ -1,0 +1,9 @@
+apiVersion: elbv2.k8s.aws/v1beta1
+kind: TargetGroupBinding
+metadata:
+  name: {{ $.Values.serviceName }}
+spec:
+  serviceRef:
+    name: {{ $.Values.serviceName }}
+    port: {{ $.Values.servicePort }}
+  targetGroupARN:  {{ $.Values.targetGroupARN }}

--- a/charts/aws-target-group-binding/values.yaml
+++ b/charts/aws-target-group-binding/values.yaml
@@ -1,0 +1,8 @@
+# -- Exact name of the service to add the binding against
+serviceName: "myservicename"
+
+# --  The port the required service is running on
+servicePort: 80
+
+# -- Amazon Resource Name (ARN) for the TargetGroup you want to use.
+targetGroupARN: "arn:1234:5678"


### PR DESCRIPTION
### target-group-mapping


As we utilise K8s more we need a way to quickly add the binding for the service to the loadbalancer without manually downloading and modifying chart templates.

**Purpose of this is to create this link :**
_Externally provisioned LB > TargetGroup > Pod > K8s Service Nodeport_ 



Definition : [Link to Module](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/guide/targetgroupbinding/targetgroupbinding)

> TargetGroupBinding is a [custom resource (CR)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) that can expose your pods using an existing [ALB TargetGroup](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html) or [NLB TargetGroup](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html).