### PR TITLE
Updated configmaps to allow N files per

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+Version 0.1.18 (2022-08-25)
+---------------------------
+charts/cron-job: Add ability to specify multiple files per config-map (#48)
+charts/service-deployment: Add ability to specify multiple files per config-map (#49)
+charts/service-deployment: Expose targetPort and protocol in service definition (#53) 
+
 Version 0.1.17 (2022-08-24)
 ---------------------------
 charts/aws-target-group-binding: Create chart (#47)

--- a/charts/cron-job/Chart.yaml
+++ b/charts/cron-job/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cron-job
 description: A Helm Chart to deploy an arbitrary container as a cron job.
-version: 0.4.3
+version: 0.5.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/cron-job/templates/configmaps.yaml
+++ b/charts/cron-job/templates/configmaps.yaml
@@ -5,7 +5,13 @@ kind: ConfigMap
 metadata:
   name: {{ $v.name }}
 binaryData:
-  {{ $v.key }}: "{{ $v.contentsB64 }}"
+  {{- range $f := $v.files }}
+  {{- if $f.contentsB64 }}
+  {{ $f.key }}: "{{ $f.contentsB64 }}"
+  {{- else }}
+  {{ $f.key }}: "{{ ($.Files.Get $f.contentsFile) | b64enc }}"
+  {{- end }}
+  {{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/cron-job/templates/deployment.yaml
+++ b/charts/cron-job/templates/deployment.yaml
@@ -17,7 +17,13 @@ spec:
           annotations:
             {{- if .Values.configMaps }}
             {{- range $v := .Values.configMaps }}
-            checksum/{{ $v.name }}-{{ $v.key }}: "{{ $v.contentsB64 | sha256sum }}"
+            {{- range $f := $v.files }}
+            {{- if $f.contentsB64 }}
+            checksum/{{ $v.name }}-{{ $f.key }}: "{{ $f.contentsB64 | sha256sum }}"
+            {{- else }}
+            checksum/{{ $v.name }}-{{ $f.key }}: "{{ ($.Files.Get $f.contentsFile) | b64enc | sha256sum }}"
+            {{- end }}
+            {{- end }}
             {{- end }}
             {{- end }}
         spec:

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -37,10 +37,12 @@ config:
 # -- List of config maps to mount to the deployment
 configMaps: []
 #  - name: "volume-1"
-#    key: "file.cfg"
-#    contentsB64: "" # The file contents which have already been base-64 encoded
 #    mountPath: "/etc/config" # Must be unique
 #    mountPropagation: None # If unset will default to 'None'
+#    files: []
+#      - key: "file.cfg" # Key must be unique for each file
+#        contentsB64: "" # The file contents which have already been base-64 encoded
+#        contentsFile: "" # The path to a local file (note: contentsB64 will take precedence if not-empty)
 
 dockerconfigjson:
   # -- Name of the secret to use for the private repository

--- a/charts/service-deployment/Chart.yaml
+++ b/charts/service-deployment/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: service-deployment
 description: A Helm Chart to setup a generic deployment with optional service/hpa bindings
-version: 0.1.3
+version: 0.2.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/service-deployment/README.md
+++ b/charts/service-deployment/README.md
@@ -67,7 +67,9 @@ helm delete service-deployment
 | hpa.maxReplicas | int | `20` | Maximum number of pods to deploy |
 | hpa.averageCPUUtilization | int | `75` | Average CPU utilization before auto-scaling starts |
 | service.deploy | bool | `true` | Whether to setup service bindings (note: only NodePort is supported) |
-| service.port | int | `80` | Port to bind and expose the service on |
+| service.port | int | `8000` | Port to bind and expose the service on |
+| service.targetPort | int | `80` | The Target Port that the actual application is being exposed on |
+| service.protocol | string | `"TCP"` | Protocol that the service leverages (note: TCP or UDP) |
 | service.aws.targetGroupARN | string | `""` | EC2 TargetGroup ARN to bind the service onto |
 | service.gcp.networkEndpointGroupName | string | `""` | Name of the Network Endpoint Group to bind onto |
 | dockerconfigjson.name | string | `"snowplow-sd-dockerhub"` | Name of the secret to use for the private repository |

--- a/charts/service-deployment/templates/NOTES.txt
+++ b/charts/service-deployment/templates/NOTES.txt
@@ -10,7 +10,7 @@ The service can be accessed via port {{ .Values.service.port }} on the following
 
 To connect to your server from outside the cluster execute the following commands:
 
-    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "app.fullname" . }} 8080:{{ .Values.service.port }}
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "app.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
 
-You can then navigate to your service in your browser at localhost:8080 or issue request with tools like cURL.
+You can then navigate to your service in your browser at localhost:{{ .Values.service.port }} or issue request with tools like cURL.
 {{- end }}

--- a/charts/service-deployment/templates/configmaps.yaml
+++ b/charts/service-deployment/templates/configmaps.yaml
@@ -5,7 +5,13 @@ kind: ConfigMap
 metadata:
   name: {{ $v.name }}
 binaryData:
-  {{ $v.key }}: "{{ $v.contentsB64 }}"
+  {{- range $f := $v.files }}
+  {{- if $f.contentsB64 }}
+  {{ $f.key }}: "{{ $f.contentsB64 }}"
+  {{- else }}
+  {{ $f.key }}: "{{ ($.Files.Get $f.contentsFile) | b64enc }}"
+  {{- end }}
+  {{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/service-deployment/templates/deployment.yaml
+++ b/charts/service-deployment/templates/deployment.yaml
@@ -13,7 +13,13 @@ spec:
       annotations:
         {{- if .Values.configMaps }}
         {{- range $v := .Values.configMaps }}
-        checksum/{{ $v.name }}-{{ $v.key }}: "{{ $v.contentsB64 | sha256sum }}"
+        {{- range $f := $v.files }}
+        {{- if $f.contentsB64 }}
+        checksum/{{ $v.name }}-{{ $f.key }}: "{{ $f.contentsB64 | sha256sum }}"
+        {{- else }}
+        checksum/{{ $v.name }}-{{ $f.key }}: "{{ ($.Files.Get $f.contentsFile) | b64enc | sha256sum }}"
+        {{- end }}
+        {{- end }}
         {{- end }}
         {{- end }}
     spec:

--- a/charts/service-deployment/templates/service.yaml
+++ b/charts/service-deployment/templates/service.yaml
@@ -15,6 +15,6 @@ spec:
   ports:
   - name: http-port
     port: {{ .Values.service.port }}
-    protocol: TCP
-    targetPort: {{ .Values.service.port }}
+    protocol: {{ .Values.service.protocol }}
+    targetPort: {{ .Values.service.targetPort }}
 {{- end }}

--- a/charts/service-deployment/values.yaml
+++ b/charts/service-deployment/values.yaml
@@ -31,10 +31,12 @@ config:
 # -- List of config maps to mount to the deployment
 configMaps: []
 #  - name: "volume-1"
-#    key: "file.cfg"
-#    contentsB64: "" # The file contents which have already been base-64 encoded
 #    mountPath: "/etc/config" # Must be unique
 #    mountPropagation: None # If unset will default to 'None'
+#    files: []
+#      - key: "file.cfg" # Key must be unique for each file
+#        contentsB64: "" # The file contents which have already been base-64 encoded
+#        contentsFile: "" # The path to a local file (note: contentsB64 will take precedence if not-empty)
 
 # -- Map of resource constraints for the service
 resources: {}

--- a/charts/service-deployment/values.yaml
+++ b/charts/service-deployment/values.yaml
@@ -74,7 +74,11 @@ service:
   # -- Whether to setup service bindings (note: only NodePort is supported)
   deploy: true
   # -- Port to bind and expose the service on
-  port: 80
+  port: 8000
+  # -- The Target Port that the actual application is being exposed on
+  targetPort: 80
+  # -- Protocol that the service leverages (note: TCP or UDP)
+  protocol: "TCP"
   aws:
     # -- EC2 TargetGroup ARN to bind the service onto
     targetGroupARN: ""


### PR DESCRIPTION
@jparavisini as this impacts one of the charts you have implemented wanted to see if you agree and if you can then update your side when this is merged?

Also updated service-deployment with a targetPort setting that needs to be set to the correct port that the container is exposing as opposed to port which is what kubernetes exposes via the service layer.  Default protocol is still TCP.