### PR TITLE
Add support for exec readiness probes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.21 (2022-09-22)
+---------------------------
+charts/service-deployment: Add support for 'exec' readiness probes in deployment (#56)
+
 Version 0.1.20 (2022-09-21)
 ---------------------------
 charts/daemonset: Add opinionated chart for deploying a daemonset (#51)

--- a/charts/service-deployment/Chart.yaml
+++ b/charts/service-deployment/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: service-deployment
 description: A Helm Chart to setup a generic deployment with optional service/hpa bindings
-version: 0.2.0
+version: 0.3.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/service-deployment/README.md
+++ b/charts/service-deployment/README.md
@@ -55,7 +55,8 @@ helm delete service-deployment
 | config.secrets | object | `{}` | Map of secrets that will be exposed as environment variables within the job |
 | configMaps | list | `[]` | List of config maps to mount to the deployment |
 | resources | object | `{}` | Map of resource constraints for the service |
-| readinessProbe.httpGet.path | string | `""` | Path for health checks to be performed (note: set to "" to disable) |
+| readinessProbe.httpGet.path | string | `""` | Path for health checks to be performed to determine readiness |
+| readinessProbe.command.exec | list | `[]` | Command/arguments to execute to determine readiness |
 | readinessProbe.initialDelaySeconds | int | `5` |  |
 | readinessProbe.periodSeconds | int | `5` |  |
 | readinessProbe.timeoutSeconds | int | `5` |  |

--- a/charts/service-deployment/templates/deployment.yaml
+++ b/charts/service-deployment/templates/deployment.yaml
@@ -80,12 +80,21 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
 
-        {{- if ne .Values.readinessProbe.httpGet.path "" }}
+        {{- if or (ne .Values.readinessProbe.httpGet.path "") (.Values.readinessProbe.exec.command) }}
         readinessProbe:
-          httpGet:
-            path: {{ .Values.readinessProbe.httpGet.path }}
-            port: {{ .Values.service.port }}
-            scheme: HTTP
+          {{- if ne .Values.readinessProbe.httpGet.path "" }}
+            httpGet:
+              path: {{ .Values.readinessProbe.httpGet.path }}
+              port: {{ .Values.service.port }}
+              scheme: HTTP
+          {{- end }}
+          {{- if gt (len .Values.readinessProbe.exec.command) 0 }}
+          exec:
+            command:
+          {{- range $v := .Values.readinessProbe.exec.command }}
+            - {{ $v }}
+          {{- end }}
+          {{- end }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/charts/service-deployment/values.yaml
+++ b/charts/service-deployment/values.yaml
@@ -47,10 +47,14 @@ resources: {}
 #    cpu: 400m
 #    memory: 512Mi
 
+# -- readinessProbe is enabled if httpGet.path or exec.command are present
 readinessProbe:
   httpGet:
-    # -- Path for health checks to be performed (note: set to "" to disable)
+    # -- Path for health checks to be performed to determine readiness
     path: ""
+  exec:
+    # -- Command/arguments to execute to determine readiness
+    command: []
   initialDelaySeconds: 5
   periodSeconds: 5
   timeoutSeconds: 5


### PR DESCRIPTION
See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command 
Note: Documentation snippet focuses on liveness probes, but the three probes share methodology 