### PR TITLE
[EP-269] Update the helm chart image for runner chart to use newer image

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.32 (2023-02-03)
+---------------------------
+charts/github-actions-runners: Changing default image tag from latests to ubuntu-22.04 (#87)
+
 Version 0.1.31 (2023-01-27)
 ---------------------------
 charts/github-actions-runners: Enable Labelling of runners within a deployment (#85)

--- a/charts/github-actions-runners/Chart.yaml
+++ b/charts/github-actions-runners/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: github-actions-runners
 description: A helm chart for deploying Github Self-hosted Runners
 type: application
-version: 0.1.1
+version: 0.1.2
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/github-actions-runners/values.yaml
+++ b/charts/github-actions-runners/values.yaml
@@ -2,7 +2,7 @@
 image:
   runnerImage: "summerwind/actions-runner"
   isRepositoryPrivate: false
-  tag: "latest"
+  tag: "ubuntu-22.04"
   pullPolicy: IfNotPresent
 # -- Overrides the name given to the deployment (default: .Release.Name)
 nameOverride: ""


### PR DESCRIPTION
Currently our helm chart [github-actions-runners 0.1.1 · snowplow/snowplow-devops](https://artifacthub.io/packages/helm/snowplow-devops/github-actions-runners) is being flagged as F for Security - the Reason for this is due to the default chart image being set to latest.

Change is to update this to newer ubuntu release