### PR TITLE
charts/aws-otel-collector: Add additional metrics

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+Version 0.1.33 (2023-03-27)
+charts/aws-otel-collector: Add additional metrics (#90)
+
 Version 0.1.32 (2023-02-03)
 ---------------------------
 charts/github-actions-runners: Changing default image tag from latests to ubuntu-22.04 (#87)

--- a/charts/aws-otel-collector/Chart.yaml
+++ b/charts/aws-otel-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-otel-collector
 description: A Helm chart to deploy aws-otel-collector project
-version: 0.1.2
+version: 0.1.3
 appVersion: "v0.17.0"
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts

--- a/charts/aws-otel-collector/templates/configmap.yaml
+++ b/charts/aws-otel-collector/templates/configmap.yaml
@@ -32,6 +32,7 @@ data:
               - pod_cpu_utilization
               - pod_memory_utilization
               - pod_number_of_running_containers
+              - pod_number_of_container_restarts
           - dimensions: [[FullPodName, Namespace, ClusterName]]
             metric_name_selectors:
               - pod_cpu_utilization


### PR DESCRIPTION
This change surfaces the `pod_number_of_container_restarts` metric to cloudwatch. 