### PR TITLE
Lake loader stuff

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -38,7 +38,7 @@ jobs:
         run: ct lint --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.8.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Version 0.1.38 (2023-09-06)
+---------------------------
+charts/service-deployment: Scaling down to zero replicas (#106)
+charts/service-deployment: Configurable autoscaling behavior (#105)
+
 Version 0.1.37 (2023-08-30)
 ---------------------------
 charts/cluster-warmer: Create chart (#101)

--- a/charts/service-deployment/Chart.yaml
+++ b/charts/service-deployment/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: service-deployment
 description: A Helm Chart to setup a generic deployment with optional service/hpa bindings
-version: 0.4.2
+version: 0.5.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/service-deployment/Chart.yaml
+++ b/charts/service-deployment/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: service-deployment
 description: A Helm Chart to setup a generic deployment with optional service/hpa bindings
-version: 0.4.1
+version: 0.4.2
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/service-deployment/templates/deployment.yaml
+++ b/charts/service-deployment/templates/deployment.yaml
@@ -3,6 +3,9 @@ kind: Deployment
 metadata:
   name: {{ include "app.fullname" . }}
 spec:
+  {{- if .Values.deployment.scaleToZero }}
+  replicas: 0
+  {{- end }}
   selector:
     matchLabels:
       app: {{ include "app.fullname" . }}

--- a/charts/service-deployment/templates/hpa.yaml
+++ b/charts/service-deployment/templates/hpa.yaml
@@ -10,7 +10,13 @@ spec:
     name: {{ include "app.fullname" . }}
   minReplicas: {{ .Values.hpa.minReplicas }}
   maxReplicas: {{ .Values.hpa.maxReplicas }}
-  targetCPUUtilizationPercentage: {{ .Values.hpa.averageCPUUtilization }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.averageCPUUtilization }}
   behavior:
     {{- toYaml .Values.hpa.behavior | nindent 4 }}
 {{- end }}

--- a/charts/service-deployment/templates/hpa.yaml
+++ b/charts/service-deployment/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.hpa.deploy }}
+{{- if and .Values.hpa.deploy (not .Values.deployment.scaleToZero) }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/service-deployment/templates/hpa.yaml
+++ b/charts/service-deployment/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.hpa.deploy }}
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "app.fullname" . }}
@@ -11,4 +11,6 @@ spec:
   minReplicas: {{ .Values.hpa.minReplicas }}
   maxReplicas: {{ .Values.hpa.maxReplicas }}
   targetCPUUtilizationPercentage: {{ .Values.hpa.averageCPUUtilization }}
+  behavior:
+    {{- toYaml .Values.hpa.behavior | nindent 4 }}
 {{- end }}

--- a/charts/service-deployment/values.yaml
+++ b/charts/service-deployment/values.yaml
@@ -114,3 +114,7 @@ cloudserviceaccount:
   gcp:
     # -- Service Account email to bind to the k8s service account
     serviceAccount: ""
+
+deployment:
+  # -- When enabled, disables the HPA and scales the deployment to zero replicas
+  scaleToZero: false

--- a/charts/service-deployment/values.yaml
+++ b/charts/service-deployment/values.yaml
@@ -73,6 +73,7 @@ hpa:
   maxReplicas: 20
   # -- Average CPU utilization before auto-scaling starts
   averageCPUUtilization: 75
+  behavior: {}
 
 service:
   # -- Whether to setup service bindings (note: only NodePort is supported)


### PR DESCRIPTION
This PR adds a `scaleToZero` feature.  It is essentially a way to disable the application, but without destroying the helm chart.

This is needed for graceful shutdown to work nicely.  Without this change, kubernetes will un-bind the service account from the deployment while the pod are still shutting down.  If that happens, the pods cannot access the GCP services they need to complete the graceful shutdown.