### PR TITLE
chart/daemonset add azure workload identity label to resource (closes #114)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.42 (2023-09-14)
+---------------------------
+charts/daemonset: Add azure workload identity label (#114)
+
 Version 0.1.41 (2023-09-13)
 ---------------------------
 charts/daemonset: Add support for Azure managed identity (#112)

--- a/charts/daemonset/Chart.yaml
+++ b/charts/daemonset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: daemonset
 description: A Helm Chart to deploy an arbitrary container as a daemonset.
-version: 0.3.0
+version: 0.3.1
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/daemonset/templates/daemonset.yaml
+++ b/charts/daemonset/templates/daemonset.yaml
@@ -10,6 +10,9 @@ spec:
     metadata:
       labels:
         app: {{ include "app.fullname" . }}
+        {{- if eq .Values.global.cloud "azure" }}
+        azure.workload.identity/use: "true"
+        {{- end }}
       annotations:
         {{- with .Values.daemonsetAnnotations }}
           {{- toYaml . | nindent 10 }}


### PR DESCRIPTION
This label required to inject AZURE workload identity env's to the resource. 