### PR TITLE
charts/cron-job add azure workload identity support (closes #134)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.52 (2023-11-07)
+---------------------------
+charts/cron-job Add azure workload identity support (#134)
+
 Version 0.1.51 (2023-10-26)
 ---------------------------
 charts/service-deployment configurable strategy type (#132)

--- a/charts/cron-job/Chart.lock
+++ b/charts/cron-job/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.1.0
 - name: cloudserviceaccount
   repository: https://snowplow-devops.github.io/helm-charts
-  version: 0.1.0
-digest: sha256:92127ad4fb4b1721b3a51927e4e199bb40ae8d26f0c85369b672845bf061ddaf
-generated: "2022-07-22T16:15:36.614861+02:00"
+  version: 0.3.0
+digest: sha256:75f92234ea471c522e2cd8072bde78e2ff3b5ecf1dbdc43d2b86ed7dcdf9ec08
+generated: "2023-11-07T09:37:17.257948Z"

--- a/charts/cron-job/Chart.yaml
+++ b/charts/cron-job/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cron-job
 description: A Helm Chart to deploy an arbitrary container as a cron job.
-version: 0.5.0
+version: 0.6.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:
@@ -17,5 +17,5 @@ dependencies:
     version: 0.1.0
     repository: "https://snowplow-devops.github.io/helm-charts"
   - name: cloudserviceaccount
-    version: 0.1.0
+    version: 0.3.0
     repository: "https://snowplow-devops.github.io/helm-charts"

--- a/charts/cron-job/README.md
+++ b/charts/cron-job/README.md
@@ -37,7 +37,7 @@ helm delete cron-job
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.cloud | string | `""` | Cloud specific bindings (options: aws, gcp) |
+| global.cloud | string | `""` | Cloud specific bindings (options: aws, gcp, azure) |
 | fullnameOverride | string | `""` | Overrides the full-name given to the deployment resources (default: .Release.Name) |
 | schedule | string | `"*/1 * * * *"` |  |
 | concurrencyPolicy | string | `"Forbid"` |  |
@@ -62,3 +62,4 @@ helm delete cron-job
 | cloudserviceaccount.name | string | `"snowplow-cron-job-service-account"` | Name of the service-account to create |
 | cloudserviceaccount.aws.roleARN | string | `""` | IAM Role ARN to bind to the k8s service account |
 | cloudserviceaccount.gcp.serviceAccount | string | `""` | Service Account email to bind to the k8s service account |
+| cloudserviceaccount.azure.managedIdentityId | string | `""` | Workload managed identity id to bind to the k8s service account |

--- a/charts/cron-job/templates/deployment.yaml
+++ b/charts/cron-job/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
         metadata:
           labels:
             app: {{ include "app.fullname" . }}
+            {{- if eq .Values.global.cloud "azure" }}
+            azure.workload.identity/use: "true"
+            {{- end }}
           annotations:
             {{- if .Values.configMaps }}
             {{- range $v := .Values.configMaps }}

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -1,5 +1,5 @@
 global:
-  # -- Cloud specific bindings (options: aws, gcp)
+  # -- Cloud specific bindings (options: aws, gcp, azure)
   cloud: ""
 
 # -- Overrides the full-name given to the deployment resources (default: .Release.Name)
@@ -67,3 +67,6 @@ cloudserviceaccount:
   gcp:
     # -- Service Account email to bind to the k8s service account
     serviceAccount: ""
+  azure:
+    # -- Workload managed identity id to bind to the k8s service account
+    managedIdentityId: ""


### PR DESCRIPTION
This add azure workload identity support to charts/cron-job. 