### PR TITLE
charts/service-deployment Fix livenessProbe success threshold errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.54 (2023-11-20)
+---------------------------
+charts/service-deployment: Fix livenessProbe successThreshold error (#138)
+
 Version 0.1.53 (2023-11-17)
 ---------------------------
 charts/service-deployment: Fix for helm releaser

--- a/charts/service-deployment/Chart.yaml
+++ b/charts/service-deployment/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: service-deployment
 description: A Helm Chart to setup a generic deployment with optional service/hpa bindings
-version: 0.10.1
+version: 0.11.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/service-deployment/values.yaml
+++ b/charts/service-deployment/values.yaml
@@ -76,7 +76,7 @@ livenessProbe:
   periodSeconds: 5
   timeoutSeconds: 5
   failureThreshold: 3
-  successThreshold: 2
+  successThreshold: 1
 
 # -- Grace period for termination of the service
 terminationGracePeriodSeconds: 60


### PR DESCRIPTION
This PR (closes #138) sets the [livenessProbe success threshold to 1](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#:~:text=Must%20be%201%20for%20liveness%20and%20startup%20Probes), following  service-deployment chart's latest version release which breaks due to ` invalid: spec.template.spec.containers[0].livenessProbe.successThreshold: Invalid value: 2: must be 1`