### PR TITLE
add priority-class chart (closes #140)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.56 (2023-11-30)
+---------------------------
+charts/priority-class: Add priority class chart (#140)
+
 Version 0.1.55 (2023-11-27)
 ---------------------------
 charts/service-deployment: Add support for priority class (#121)

--- a/charts/priority-class/Chart.yaml
+++ b/charts/priority-class/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: priority-class
+description: A Helm Chart to setup priority classes for all tiers
+version: 0.1.0
+icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
+home: https://github.com/snowplow-devops/helm-charts
+sources:
+  - https://github.com/snowplow-devops/helm-charts
+maintainers:
+  - name: ianarsenault
+    url: https://github.com/ianarsenault
+    email: ianarsenault@users.noreply.github.com
+keywords:
+  - priority-class
+  - priority-classes

--- a/charts/priority-class/README.md
+++ b/charts/priority-class/README.md
@@ -1,0 +1,42 @@
+# priority-class
+
+A Helm chart to deploy generic priority classes for all tiers.
+
+## TL;DR
+
+```bash
+helm repo add snowplow-devops https://snowplow-devops.github.io/helm-charts
+helm install priority-class snowplow-devops/priority-class
+```
+
+## Introduction
+
+This chart attempts to take care of deploying a set of generic priority classes that cover all use cases for pod prioritization
+
+- **Critical** - Used for mission critical priority pods that preempt all other priority classes
+- **High** - High priority pods that preempt medium and low priority pods
+- **Medium** - Medium priority pods to be used as default with  `globalDefault: true`
+- **Low** - Lowest priority pods
+
+## Installing the Chart
+
+Install or upgrading the chart with default configuration:
+
+```bash
+helm upgrade --install priority-class snowplow-devops/priority-class
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `priority-class` release:
+
+```bash
+helm delete priority-class
+```
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| nameOverride | string | `""` | Overrides the name given to the deployment resources (default: .Release.Name) |
+| fullnameOverride | string | `""` | Overrides the full-name given to the deployment resources (default: .Release.Name) |

--- a/charts/priority-class/templates/_helpers.tpl
+++ b/charts/priority-class/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "priority-class.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "priority-class.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "priority-class.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "priority-class.labels" -}}
+helm.sh/chart: {{ include "priority-class.chart" . }}
+{{ include "priority-class.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "priority-class.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "priority-class.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/priority-class/templates/priority-class.yaml
+++ b/charts/priority-class/templates/priority-class.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.priorityClasses }}
+{{- range $PriorityClass := .Values.priorityClasses }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ $PriorityClass.name }}
+  labels:
+    {{- include "priority-class.labels" $ | nindent 4 }}
+{{- if $PriorityClass.description }}
+description: {{ $PriorityClass.description }}
+{{- end }}
+{{- if or (eq $PriorityClass.globalDefault true) (eq $PriorityClass.globalDefault false) }}
+globalDefault: {{ $PriorityClass.globalDefault }}
+{{- end }}
+{{- if $PriorityClass.preemptionPolicy }}
+preemptionPolicy: {{ $PriorityClass.preemptionPolicy }}
+{{- end }}
+value: {{ $PriorityClass.value }}
+---
+{{- end }}
+{{- end }}

--- a/charts/priority-class/values.yaml
+++ b/charts/priority-class/values.yaml
@@ -1,0 +1,26 @@
+# -- Overrides the name given to the deployment (default: .Release.Name)
+nameOverride: ""
+# -- Overrides the full-name given to the deployment resources (default: .Release.Name)
+fullnameOverride: ""
+
+priorityClasses:
+  - name: critical
+    description: "Critical priority pods that preempt all other priority classes."
+    globalDefault: false
+    preemptionPolicy: PreemptLowerPriority
+    value: 1000000
+  - name: high
+    description: "High priority pods that preempt medium and low tier priority classes."
+    globalDefault: false
+    preemptionPolicy: PreemptLowerPriority
+    value: 900000
+  - name: medium
+    description: "Medium priority pods that preempt low tier priority classes. The default for services."
+    globalDefault: true
+    preemptionPolicy: PreemptLowerPriority
+    value: 500000
+  - name: low
+    description: "Low priority pods."
+    globalDefault: false
+    preemptionPolicy: Never
+    value: 100000


### PR DESCRIPTION
This PR adds a new priority class helm chart that deploys 4 priority classes and one global default (medium).

```
➜ k get priorityclass -A
NAME                      VALUE        GLOBAL-DEFAULT   AGE
critical                  1000000      false            7s
high                      900000       false            7s
low                       100000       false            7s
medium                    500000       true             7s
system-cluster-critical   2000000000   false            14h
system-node-critical      2000001000   false            14h
```