### PR TITLE
charts/service-deployment: add affinity settings (closes #142 and #145)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.57 (2023-12-07)
+---------------------------
+charts/service-deployment: Add affinity settings (#142 and #145)
+
 Version 0.1.56 (2023-11-30)
 ---------------------------
 charts/service-deployment: Add rollingUpdate settings (#144)

--- a/charts/service-deployment/Chart.yaml
+++ b/charts/service-deployment/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: service-deployment
 description: A Helm Chart to setup a generic deployment with optional service/hpa bindings
-version: 0.13.0
+version: 0.14.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/service-deployment/README.md
+++ b/charts/service-deployment/README.md
@@ -90,3 +90,4 @@ helm delete service-deployment
 | service.targetPort | int | `80` | The Target Port that the actual application is being exposed on |
 | terminationGracePeriodSeconds | int | `60` | Grace period for termination of the service |
 | priorityClassName | string | `""` | `priorityClassName` for pods |
+| affinity | object | `{}` | Map of affinity constraints that will be used when scheduling pods |

--- a/charts/service-deployment/templates/deployment.yaml
+++ b/charts/service-deployment/templates/deployment.yaml
@@ -61,6 +61,11 @@ spec:
       {{- end }}
       {{- end }}
 
+      {{- if .Values.affinity }}
+      affinity:
+      {{- toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
+
       containers:
       - name: "{{ include "app.fullname" . }}"
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/service-deployment/values.yaml
+++ b/charts/service-deployment/values.yaml
@@ -159,3 +159,34 @@ deployment:
       maxSurge: "25%"
 
 priorityClassName: ""
+
+# -- Affinity supports podAffinity, podAntiAffinity, or nodeAffinity
+affinity: {}
+# podAffinity:
+#    requiredDuringSchedulingIgnoredDuringExecution:
+#    - labelSelector:
+#        matchExpressions:
+#        - key: security
+#          operator: In
+#          values:
+#          - S1
+#      topologyKey: topology.kubernetes.io/zone
+# podAntiAffinity:
+#   preferredDuringSchedulingIgnoredDuringExecution:
+#   - weight: 100
+#     podAffinityTerm:
+#       labelSelector:
+#         matchExpressions:
+#         - key: app.kubernetes.io/name
+#           operator: In
+#           values:
+#           - collector
+#       topologyKey: topology.kubernetes.io/hostname
+# nodeAffinity:
+#    requiredDuringSchedulingIgnoredDuringExecution:
+#      nodeSelectorTerms:
+#      - matchExpressions:
+#        - key: kubernetes.io/os
+#          operator: In
+#          values:
+#          - linux


### PR DESCRIPTION
Closes #142 and #145.

Adds option to include affinity constraints to be used when scheduling pods. The affinity block supports pod affinity, antiAffinity or nodeAffinity options. Two or all three of these options can be used together as long as they don't negate each other.
Each option has a variety of settings that can be configured; see [K8s docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) for more details. 