### PR TITLE
Update conditional logic for NEGs and Targetgroup bindings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Version 0.1.58 (2023-12-08)
+---------------------------
+charts/service-deployment: Update conditional logic for NEGs and Targetgroup bindings (#148)
+charts/snowplow-iglu-server: Update conditional logic for NEGs and Targetgroup bindings (#148)
+
 Version 0.1.57 (2023-12-07)
 ---------------------------
 charts/service-deployment: Add affinity settings (#142 and #145)

--- a/charts/service-deployment/Chart.yaml
+++ b/charts/service-deployment/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: service-deployment
 description: A Helm Chart to setup a generic deployment with optional service/hpa bindings
-version: 0.14.0
+version: 0.14.1
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/service-deployment/templates/service.yaml
+++ b/charts/service-deployment/templates/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "app.fullname" . }}
-  {{- if and (eq .Values.global.cloud "gcp") (not .Values.service.ingress.enableTraefik) }}
+  {{- if and (eq .Values.global.cloud "gcp") (ne .Values.service.gcp.networkEndpointGroupName "") }}
   annotations:
     cloud.google.com/app-protocols:  '{"http-port": "HTTP"}'
     cloud.google.com/neg: '{"exposed_ports": {"{{ .Values.service.port }}":{"name": "{{ include "service.gcp.networkEndpointGroupName" . }}"}}}'

--- a/charts/service-deployment/templates/targetgroupbinding.yaml
+++ b/charts/service-deployment/templates/targetgroupbinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.service.deploy }}
-{{- if and (eq .Values.global.cloud "aws") (not .Values.global.deployTraefikIngress) }}
+{{- if and (eq .Values.global.cloud "aws")  (ne .Values.service.aws.targetGroupARN "") }}
 apiVersion: elbv2.k8s.aws/v1beta1
 kind: TargetGroupBinding
 metadata:

--- a/charts/snowplow-iglu-server/Chart.yaml
+++ b/charts/snowplow-iglu-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: snowplow-iglu-server
 description: A Helm Chart to deploy the Snowplow Iglu Server project
-version: 0.3.0
+version: 0.3.1
 appVersion: "0.10.0"
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts

--- a/charts/snowplow-iglu-server/templates/iglu-service.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "iglu.app.name" . }}
-  {{- if and (eq .Values.global.cloud "gcp") (not .Values.global.deployTraefikIngress) }}
+  {{- if and (eq .Values.global.cloud "gcp") (ne .Values.service.gcp.networkEndpointGroupName "") }}
   annotations:
     cloud.google.com/app-protocols:  '{"http-port": "HTTP"}'
     cloud.google.com/neg: '{"exposed_ports": {"{{ .Values.service.port }}":{"name": "{{ include "iglu.service.gcp.networkEndpointGroupName" . }}"}}}'

--- a/charts/snowplow-iglu-server/templates/iglu-targetgroupbinding.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-targetgroupbinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.global.cloud "aws") (not .Values.global.deployTraefikIngress) }}
+{{- if and (eq .Values.global.cloud "aws") (ne .Values.service.aws.targetGroupARN "") }}
 apiVersion: elbv2.k8s.aws/v1beta1
 kind: TargetGroupBinding
 metadata:

--- a/charts/snowplow-iglu-server/values-azure.yaml.tmpl
+++ b/charts/snowplow-iglu-server/values-azure.yaml.tmpl
@@ -1,6 +1,5 @@
 global:
   cloud: "azure"
-  deployTraefikIngress: true
 
 service:
   deploySetupHooks: true
@@ -28,6 +27,6 @@ service:
         password: "<password>"
     patchesAllowed: false
 
-  traefik:
-    hostname: "iglu-server.example.com"
-    entrypoint: "websecure"
+  ingress: 
+    ingress-01:
+      hostname: "iglu-server.example.com"


### PR DESCRIPTION
This change repairs the conditional logic for deploying services associated with both GCP NEGs and AWS target groups. (#148)
Additionally, it updates the azure sample values yaml for `charts/snowplow-iglu-server` to reflect the current state of the chart. 