### PR TITLE
charts/service deployment: 0.15.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.60 (2023-12-18)
+---------------------------
+charts/service-deployment: Allow disabling SA once bound (#152)
+
 Version 0.1.59 (2023-12-15)
 ---------------------------
 charts/service-deployment: Add support for PersistentVolumeClaim (#150)

--- a/charts/service-deployment/Chart.yaml
+++ b/charts/service-deployment/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: service-deployment
 description: A Helm Chart to setup a generic deployment with optional service/hpa bindings
-version: 0.15.0
+version: 0.15.1
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/service-deployment/templates/deployment.yaml
+++ b/charts/service-deployment/templates/deployment.yaml
@@ -37,7 +37,11 @@ spec:
         {{- end }}
     spec:
       {{- if .Values.cloudserviceaccount.deploy }}
+      serviceAccount: {{ .Values.cloudserviceaccount.name }}
       serviceAccountName: {{ .Values.cloudserviceaccount.name }}
+      {{- else }}
+      serviceAccount: ""
+      serviceAccountName: ""
       {{- end }}
       automountServiceAccountToken: true
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}


### PR DESCRIPTION
This ensures that when the csa is disabled that it gets unset from the deployment spec properly as omission is not enough to unset and will break later deployments.