### PR TITLE
charts/cluster-warmer add nodeSelector for scheduling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.63 (2024-01-30)
+---------------------------
+charts/cluster-warmer: add nodeSelector for scheduling (#161)
+
 Version 0.1.62 (2024-01-25)
 ---------------------------
 charts/snowplow-iglu-server: Add support for sending HSTS headers (#154)

--- a/charts/cluster-warmer/Chart.yaml
+++ b/charts/cluster-warmer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cluster-warmer
 description: A Helm Chart to deploy pods to force scaling in a node-pool to keep it warm
-version: 0.1.0
+version: 0.2.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/cluster-warmer/README.md
+++ b/charts/cluster-warmer/README.md
@@ -1,6 +1,6 @@
 # cluster-warmer
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square)
 
 A Helm Chart to deploy pods to force scaling in a node-pool to keep it warm
 
@@ -26,6 +26,7 @@ A Helm Chart to deploy pods to force scaling in a node-pool to keep it warm
 | image.pullPolicy | string | `"IfNotPresent"` | The image pullPolicy to use |
 | image.repository | string | `"registry.k8s.io/pause"` |  |
 | image.tag | string | `"3.9"` |  |
+| nodeSelector | object | `{}` | nodeSelector configuration |
 | resources | object | `{}` | Map of resource constraints for the warm pods (should be set to a sufficiently high number to trigger scaling) |
 
 ----------------------------------------------

--- a/charts/cluster-warmer/templates/deployment.yaml
+++ b/charts/cluster-warmer/templates/deployment.yaml
@@ -12,6 +12,10 @@ spec:
         app: {{ include "app.fullname" . }}
     spec:
       priorityClassName: {{ include "app.fullname" . }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 0
       containers:
       - name: "{{ include "app.fullname" . }}"

--- a/charts/cluster-warmer/values.yaml
+++ b/charts/cluster-warmer/values.yaml
@@ -17,3 +17,6 @@ resources: {}
 hpa:
   # -- Number of replicas to setup to manage how many warm nodes are created
   replicas: 1
+
+# --  Node labels for pod assignment.
+nodeSelector: {}


### PR DESCRIPTION
This PR updates cluster-warmer helm chart to allow specifying nodeSelector labels to schedule the cluster warmer pod on specific node pool nodes