### PR TITLE
Add support for IP allowlists on ingress in charts/service-deployment and charts/snowplow-iglu-server

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Version 0.1.65 (2024-03-26)
+---------------------------
+charts/service-deployment: Add support for IP allowlists on ingress (#167)
+charts/snowplow-iglu-server: Add support for IP allowlists on ingress (#168)
+
 Version 0.1.64 (2024-02-14)
 ---------------------------
 charts/service-deployment: Updating secrets does not trigger deployment updates (#163)

--- a/charts/service-deployment/Chart.yaml
+++ b/charts/service-deployment/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: service-deployment
 description: A Helm Chart to setup a generic deployment with optional service/hpa bindings
-version: 0.16.1
+version: 0.17.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/service-deployment/templates/ingress.yaml
+++ b/charts/service-deployment/templates/ingress.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- if .enableTraefik | default "true" }}
     traefik.ingress.kubernetes.io/router.entrypoints: "web, websecure"
   {{- end}}
+  {{- if $.Values.service.ingressIPAllowlist }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace}}-{{ include "app.fullname" $ }}-ipallowlist@kubernetescrd
+  {{- end }}
 spec:
   {{- if .enableTraefik | default "true" }}
   ingressClassName: traefik

--- a/charts/service-deployment/templates/ipallowlist.yaml
+++ b/charts/service-deployment/templates/ipallowlist.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.service.ingressIPAllowlist .Values.service.ingress -}}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "app.fullname" . }}-ipallowlist
+spec:
+  ipWhiteList:
+    sourceRange:
+      {{- range $ip := .Values.service.ingressIPAllowlist }}
+      - "{{ $ip }}"
+      {{- end }}
+{{- end -}}

--- a/charts/service-deployment/values.yaml
+++ b/charts/service-deployment/values.yaml
@@ -120,7 +120,9 @@ service:
     #   certificateIssuerName: cloudflare # -- What issuer to use for the Certificate (default: letsencrypt-staging)
     #   certificateIssuerKind: Issuer # -- Kind of issuer (default: ClusterIssuer)
     #   enableTraefik: false # -- Enables traefik annotations and set ingressClassName. (default: true)
-    #   annotations: {} # -- Map of annotations to add to the ingress.
+    #   annotations: {} # -- Map of annotations to add to the ingress
+  # -- List of IP addresses to restrict ingress traffic to
+  ingressIPAllowlist: []
 
 dockerconfigjson:
   # -- Name of the secret to use for the private repository

--- a/charts/snowplow-iglu-server/Chart.yaml
+++ b/charts/snowplow-iglu-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: snowplow-iglu-server
 description: A Helm Chart to deploy the Snowplow Iglu Server project
-version: 0.4.1
+version: 0.5.0
 appVersion: "0.12.0"
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts

--- a/charts/snowplow-iglu-server/templates/iglu-ingress.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-ingress.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- if $.Values.service.ingress.enableTraefik | default "true" }}
     traefik.ingress.kubernetes.io/router.entrypoints: "web, websecure"
   {{- end}}
+  {{- if $.Values.service.ingressIPAllowlist }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace}}-{{ include "iglu.app.name" $ }}-ipallowlist@kubernetescrd
+  {{- end }}
 spec:
   {{- if $.Values.service.ingress.enableTraefik | default "true" }}
   ingressClassName: traefik

--- a/charts/snowplow-iglu-server/templates/iglu-ipallowlist.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-ipallowlist.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.service.ingressIPAllowlist .Values.service.ingress -}}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "iglu.app.name" . }}-ipallowlist
+spec:
+  ipWhiteList:
+    sourceRange:
+      {{- range $ip := .Values.service.ingressIPAllowlist }}
+      - "{{ $ip }}"
+      {{- end }}
+{{- end -}}

--- a/charts/snowplow-iglu-server/values.yaml
+++ b/charts/snowplow-iglu-server/values.yaml
@@ -109,13 +109,15 @@ service:
 
   # -- A map of ingress rules to deploy
   ingress: {}
-    # enableTraefik: false # -- Enables traefik annotations and set ingressClassName. (default: true)
     # ingress-01:
+    #   enableTraefik: false # -- Enables traefik annotations and set ingressClassName. (default: true)
     #   hostname: "iglu-server.example.com"
     #   certificateCreate: false # -- Create a Certificate resource for this Ingress (default: true)
     #   certificateIssuerName: cloudflare # -- What issuer to use for the Certificate (default: letsencrypt)
     #   certificateIssuerKind: Issuer # -- Kind of issuer (default: ClusterIssuer)
     #   annotations: {} # -- Map of annotations to add to the ingress.
+  # -- List of IP addresses to restrict ingress traffic to
+  ingressIPAllowlist: []
 
 cloudserviceaccount:
   # -- Whether to create a service-account


### PR DESCRIPTION
This PR adds support for creating IP allowlists used by ingresses in the charts/service-deployment and charts/snowplow-iglu-server charts respectively. 
The current implementation is limited to Traefik allowlisting (https://doc.traefik.io/traefik/middlewares/http/ipwhitelist/) but is flexible enough to allow adding in additional ingress controllers such as nginx-ingress in the future.