### PR TITLE
Service Deployment v0.18.0 with StatefulSets

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.66 2024-03-27)
+---------------------------
+charts/service-deployment: Add support for StatefulSet in deployment.Kind (#170)
+
 Version 0.1.65 (2024-03-26)
 ---------------------------
 charts/service-deployment: Add support for IP allowlists on ingress (#167)

--- a/charts/service-deployment/Chart.yaml
+++ b/charts/service-deployment/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: service-deployment
 description: A Helm Chart to setup a generic deployment with optional service/hpa bindings
-version: 0.17.0
+version: 0.18.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/service-deployment/README.md
+++ b/charts/service-deployment/README.md
@@ -18,6 +18,7 @@ This chart attempts to take care of all the most common requirements of launchin
 - Mounting config volumes
 - Configuring secrets
 - Binding service-accounts with cloud specific IAM policies
+- Setting up persistent-volumes and binding them
 
 _Note_: This should be a long running process - if you are looking for cron-based execution see our `cron-job` chart.
 
@@ -55,6 +56,7 @@ helm delete service-deployment
 | config.secrets | object | `{}` | Map of secrets that will be exposed as environment variables within the job |
 | config.secretsB64 | object | `{}` | Map of base64-encoded secrets that will be exposed as environment variables within the job |
 | configMaps | list | `[]` | List of config maps to mount to the deployment |
+| deployment.kind | string | `"Deployment"` | Can be either a "Deployment" or "StatefulSet" |
 | deployment.podLabels | object | `{}` | Map of labels that will be added to each pod in the deployment |
 | deployment.scaleToZero | bool | `false` | When enabled, disables the HPA and scales the deployment to zero replicas |
 | deployment.strategy | object | `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"}` | How to replace existing pods with new ones |
@@ -80,12 +82,15 @@ helm delete service-deployment
 | livenessProbe | object | `{"exec":{"command":[]},"failureThreshold":3,"httpGet":{"path":"","port":""},"initialDelaySeconds":5,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":5}` | livenessProbe is enabled if httpGet.path or exec.command are present |
 | livenessProbe.exec.command | list | `[]` | Command/arguments to execute to determine liveness |
 | livenessProbe.httpGet.path | string | `""` | Path for health checks to be performed to determine liveness |
-| persistentVolume.accessModes | list | `["ReadWriteOnce"]` | Access modes to allow (note: this will impact HPA rules if the volume cannot be bound to all containers) |
+| persistentVolume.accessModes | list | `["ReadWriteOnce"]` | Access modes to allow (note: this will impact HPA rules if the volume cannot be bound to all containers when deployment.kind is "Deployment") |
 | persistentVolume.annotations | object | `{}` | Persistent Volume annotations |
-| persistentVolume.enabled | bool | `false` | Whether to deploy a persistent-volume |
+| persistentVolume.enabled | bool | `false` | Whether to deploy a persistent-volume (note: when deployment.kind is "StatefulSet" one volume will be created per replica) |
 | persistentVolume.labels | object | `{}` | Persistent Volume labels |
 | persistentVolume.mountPath | string | `"/data"` | Persistent Volume mount root path |
 | persistentVolume.size | string | `"8Gi"` | Persistent Volume size |
+| persistentVolume.statefulSetRetentionPolicy | object | `{"whenDeleted":"Retain","whenScaled":"Delete"}` | Sets the retention policies for the volumes created in "StatefulSet" mode |
+| persistentVolume.statefulSetRetentionPolicy.whenDeleted | string | `"Retain"` | What to do with volumes when the StatefulSet is deleted |
+| persistentVolume.statefulSetRetentionPolicy.whenScaled | string | `"Delete"` | What to do with volumes when scaling occurs |
 | persistentVolume.subPath | string | `""` | Subdirectory of Persistent Volume to mount |
 | priorityClassName | string | `""` | PriorityClassName for pods |
 | readinessProbe | object | `{"exec":{"command":[]},"failureThreshold":3,"httpGet":{"path":""},"initialDelaySeconds":5,"periodSeconds":5,"successThreshold":2,"timeoutSeconds":5}` | readinessProbe is enabled if httpGet.path or exec.command are present |

--- a/charts/service-deployment/templates/deployment.yaml
+++ b/charts/service-deployment/templates/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ .Values.deployment.kind }}
 metadata:
   name: {{ include "app.fullname" . }}
 spec:
@@ -71,7 +71,7 @@ spec:
           optional: false
         name: {{ $v.name }}
       {{- end }}
-      {{- if .Values.persistentVolume.enabled }}
+      {{- if and (.Values.persistentVolume.enabled) (eq .Values.deployment.kind "Deployment") }}
       - name: storage-volume
         persistentVolumeClaim:
           claimName: {{ include "app.fullname" . }}
@@ -172,8 +172,42 @@ spec:
           {{- end }}
           name: {{ $v.name }}
         {{- end }}
-        {{- if .Values.persistentVolume.enabled }}
+        {{- if and (.Values.persistentVolume.enabled) (eq .Values.deployment.kind "Deployment") }}
         - name: storage-volume
           mountPath: {{ .Values.persistentVolume.mountPath }}
           subPath: "{{ .Values.persistentVolume.subPath }}"
         {{- end }}
+        {{- if and (.Values.persistentVolume.enabled) (eq .Values.deployment.kind "StatefulSet") }}
+        - name: {{ include "app.fullname" . }}
+          mountPath: {{ .Values.persistentVolume.mountPath }}
+          subPath: "{{ .Values.persistentVolume.subPath }}"
+        {{- end }}
+  {{- if and (.Values.persistentVolume.enabled) (eq .Values.deployment.kind "StatefulSet") }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.persistentVolume.statefulSetRetentionPolicy.whenDeleted }}
+    whenScaled: {{ .Values.persistentVolume.statefulSetRetentionPolicy.whenScaled }}
+  volumeClaimTemplates:
+  - metadata:
+      annotations:
+        {{- with .Values.persistentVolume.annotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- with .Values.persistentVolume.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      name: {{ include "app.fullname" . }}
+    spec:
+      accessModes:
+{{ toYaml .Values.persistentVolume.accessModes | indent 6 }}
+    {{- if .Values.persistentVolume.storageClass }}
+    {{- if (eq "-" .Values.persistentVolume.storageClass) }}
+      storageClassName: ""
+    {{- else }}
+      storageClassName: "{{ .Values.persistentVolume.storageClass }}"
+    {{- end }}
+    {{- end }}
+      resources:
+        requests:
+          storage: "{{ .Values.persistentVolume.size }}"
+  {{- end }}

--- a/charts/service-deployment/templates/hpa.yaml
+++ b/charts/service-deployment/templates/hpa.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: {{ .Values.deployment.kind }}
     name: {{ include "app.fullname" . }}
   minReplicas: {{ .Values.hpa.minReplicas }}
   maxReplicas: {{ .Values.hpa.maxReplicas }}

--- a/charts/service-deployment/templates/pvc.yaml
+++ b/charts/service-deployment/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistentVolume.enabled -}}
+{{- if and (.Values.persistentVolume.enabled) (eq .Values.deployment.kind "Deployment") }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/service-deployment/values.yaml
+++ b/charts/service-deployment/values.yaml
@@ -108,7 +108,7 @@ service:
   gcp:
     # -- Name of the Network Endpoint Group to bind onto
     networkEndpointGroupName: ""
-  # -- Map of annotations to add to the service.
+  # -- Map of annotations to add to the service
   annotations: {}
   # -- A map of ingress rules to deploy
   ingress: {}
@@ -152,6 +152,8 @@ cloudserviceaccount:
     managedIdentityId: ""
 
 deployment:
+  # -- Can be either a "Deployment" or "StatefulSet"
+  kind: "Deployment"
   # -- When enabled, disables the HPA and scales the deployment to zero replicas
   scaleToZero: false
   # -- How to replace existing pods with new ones
@@ -203,11 +205,17 @@ affinity: {}
 #          - linux
 
 persistentVolume:
-  # -- Whether to deploy a persistent-volume
+  # -- Whether to deploy a persistent-volume (note: when deployment.kind is "StatefulSet" one volume will be created per replica)
   enabled: false
-  # -- Access modes to allow (note: this will impact HPA rules if the volume cannot be bound to all containers)
+  # -- Access modes to allow (note: this will impact HPA rules if the volume cannot be bound to all containers when deployment.kind is "Deployment")
   accessModes:
     - ReadWriteOnce
+  # -- Sets the retention policies for the volumes created in "StatefulSet" mode
+  statefulSetRetentionPolicy:
+    # -- What to do with volumes when the StatefulSet is deleted
+    whenDeleted: "Retain"
+    # -- What to do with volumes when scaling occurs
+    whenScaled: "Delete"
   # -- Persistent Volume labels
   labels: {}
   # -- Persistent Volume annotations


### PR DESCRIPTION
This update allows us to leverage the existing chart as a StatefulSet with full PVC support baked in.  The main difference between these two kinds of deployment is that:

1. Each pod in a StatefulSet has a consistent numerically iterated name (this also applies to upgrade order)
2. When PVCs are enabled rather than creating a single volume for _all_ pods to share we instead shift to a `volumeTemplate` that lets us create a PVC _per_ pod.  These volumes get re-attached to the pod with the same name when upgrades happen / pods move between k8s cluster nodes.
3. The behaviour of PVCs in this mode can also be controlled to either Retain or Delete the volume.  By default I have set that on scale_down we Delete the PVC but when we issue a general service removal (`helm delete`) this retains the volumes (this is the default in the docs) - a user should configure this to suit their own needs!