### PR TITLE
charts/service-deployment: Add support for global labels (closes #177)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.68 (2024-07-30)
+---------------------------
+charts/service-deployment: Add support for global labels applied to resources deployed by the chart (#177)
+
 Version 0.1.67 (2024-06-27)
 ---------------------------
 charts/aws-otel-collector: Update otel-agent-config with new dimension 'ClusterName' and additional metrics (#173)

--- a/charts/service-deployment/Chart.yaml
+++ b/charts/service-deployment/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: service-deployment
 description: A Helm Chart to setup a generic deployment with optional service/hpa bindings
-version: 0.18.0
+version: 0.19.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/service-deployment/README.md
+++ b/charts/service-deployment/README.md
@@ -70,6 +70,7 @@ helm delete service-deployment
 | dockerconfigjson.username | string | `""` | Username for the private repository |
 | fullnameOverride | string | `""` | Overrides the full-name given to the deployment resources (default: .Release.Name) |
 | global.cloud | string | `""` | Cloud specific bindings (options: aws, gcp , azure) |
+| global.labels | object | `{}` | Global labels deployed to all resources deployed by the chart |
 | hpa.averageCPUUtilization | int | `75` | Average CPU utilization before auto-scaling starts |
 | hpa.behavior | object | `{}` |  |
 | hpa.deploy | bool | `true` | Whether to deploy HPA rules |

--- a/charts/service-deployment/templates/_helpers.tpl
+++ b/charts/service-deployment/templates/_helpers.tpl
@@ -21,3 +21,24 @@ Define the default NEG name for GCP deployments.
 {{- define "service.gcp.networkEndpointGroupName" -}}
 {{- default .Release.Name .Values.service.gcp.networkEndpointGroupName -}}
 {{- end -}}
+
+{{/*
+Create chart name and version to use as chart label.
+*/}}
+{{- define "service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Snowplow labels
+*/}}
+{{- define "snowplow.labels" -}}
+{{- with .Values.global.labels -}}
+{{ toYaml . }}
+{{ end -}}
+helm.sh/chart: {{ include "service.chart" . }}
+{{- if .Chart.Version }}
+app.kubernetes.io/version: {{ .Chart.Version | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/service-deployment/templates/certificate.yaml
+++ b/charts/service-deployment/templates/certificate.yaml
@@ -5,6 +5,8 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ required "A valid hostname is required!" .hostname }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 spec:
   secretName: {{ .hostname }}-tls
   issuerRef:

--- a/charts/service-deployment/templates/configmaps.yaml
+++ b/charts/service-deployment/templates/configmaps.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ $v.name }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 binaryData:
   {{- range $f := $v.files }}
   {{- if $f.contentsB64 }}

--- a/charts/service-deployment/templates/deployment.yaml
+++ b/charts/service-deployment/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       labels:
+        {{ include "snowplow.labels" $ | nindent 8 }}
         {{- if .Values.deployment.podLabels }}
         {{- toYaml .Values.deployment.podLabels | nindent 8 }}
         {{- end }}

--- a/charts/service-deployment/templates/hpa.yaml
+++ b/charts/service-deployment/templates/hpa.yaml
@@ -3,6 +3,8 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "app.fullname" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/service-deployment/templates/ingress.yaml
+++ b/charts/service-deployment/templates/ingress.yaml
@@ -4,6 +4,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ required "A valid hostname is required!" .hostname }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
   annotations:
   {{- if .annotations }}
     {{- toYaml .annotations | nindent 4 }}

--- a/charts/service-deployment/templates/ipallowlist.yaml
+++ b/charts/service-deployment/templates/ipallowlist.yaml
@@ -3,6 +3,8 @@ apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: {{ include "app.fullname" . }}-ipallowlist
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 spec:
   ipWhiteList:
     sourceRange:

--- a/charts/service-deployment/templates/pvc.yaml
+++ b/charts/service-deployment/templates/pvc.yaml
@@ -7,6 +7,7 @@ metadata:
 {{ toYaml .Values.persistentVolume.annotations | indent 4 }}
   {{- end }}
   labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
     {{- with .Values.persistentVolume.labels }}
        {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/service-deployment/templates/secrets.yaml
+++ b/charts/service-deployment/templates/secrets.yaml
@@ -4,6 +4,8 @@ kind: Secret
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ include "app.secret.fullname" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 type: Opaque
 data:
   {{- range $k, $v := .Values.config.secrets }}

--- a/charts/service-deployment/templates/service.yaml
+++ b/charts/service-deployment/templates/service.yaml
@@ -11,6 +11,8 @@ metadata:
     cloud.google.com/app-protocols:  '{"http-port": "HTTP"}'
     cloud.google.com/neg: '{"exposed_ports": {"{{ .Values.service.port }}":{"name": "{{ include "service.gcp.networkEndpointGroupName" . }}"}}}'
   {{- end }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 spec:
   type: NodePort
   selector:

--- a/charts/service-deployment/templates/targetgroupbinding.yaml
+++ b/charts/service-deployment/templates/targetgroupbinding.yaml
@@ -4,6 +4,8 @@ apiVersion: elbv2.k8s.aws/v1beta1
 kind: TargetGroupBinding
 metadata:
   name: {{ include "app.fullname" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 spec:
   serviceRef:
     name: {{ include "app.fullname" . }}

--- a/charts/service-deployment/values.yaml
+++ b/charts/service-deployment/values.yaml
@@ -2,6 +2,9 @@ global:
   # -- Cloud specific bindings (options: aws, gcp , azure)
   cloud: ""
 
+  # global labels will be applied to all resources deployed by the chart
+  labels: {}
+
 # -- Overrides the full-name given to the deployment resources (default: .Release.Name)
 fullnameOverride: ""
 


### PR DESCRIPTION
This PR adds support for passing in global labels which will be applied to all resources deployed by the chart.