### PR TITLE
Charts updates to add global labels

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-Version 0.1.70 (2024-07-31)
+Version 0.1.70 (2024-08-15)
 ---------------------------
 charts/snowplow-iglu-server add global labels (closes #179)
 charts/priority-class add global labels (closes #180)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+Version 0.1.70 (2024-07-31)
+---------------------------
+charts/snowplow-iglu-server add global labels (closes #179)
+charts/priority-class add global labels (closes #180)
+charts/daemonset add global labels (closes #181)
+charts/cron-job add global labels (closes #182)
+charts/cluster-warmer add global labels (closes #183)
+
 Version 0.1.69 (2024-07-31)
 ---------------------------
 charts/service-deployment: Add missing global labels to Deployment (#185)

--- a/charts/cluster-warmer/Chart.yaml
+++ b/charts/cluster-warmer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cluster-warmer
 description: A Helm Chart to deploy pods to force scaling in a node-pool to keep it warm
-version: 0.2.0
+version: 0.3.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/cluster-warmer/README.md
+++ b/charts/cluster-warmer/README.md
@@ -21,6 +21,7 @@ A Helm Chart to deploy pods to force scaling in a node-pool to keep it warm
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | fullnameOverride | string | `""` | Overrides the full-name given to the deployment resources (default: .Release.Name) |
+| global.labels | object | `{}` | Global labels deployed to all resources deployed by the chart |
 | hpa.replicas | int | `1` | Number of replicas to setup to manage how many warm nodes are created |
 | image.isRepositoryPublic | bool | `true` | Whether the repository is public |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pullPolicy to use |

--- a/charts/cluster-warmer/templates/_helpers.tpl
+++ b/charts/cluster-warmer/templates/_helpers.tpl
@@ -11,3 +11,24 @@ If release name contains chart name it will be used as a full name.
 {{- .Release.Name | trunc 50 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create chart name and version to use as chart label.
+*/}}
+{{- define "cluster.warmer.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Snowplow labels
+*/}}
+{{- define "snowplow.labels" -}}
+{{- with .Values.global.labels -}}
+{{ toYaml . }}
+{{ end -}}
+helm.sh/chart: {{ include "cluster.warmer.chart" . }}
+{{- if .Chart.Version }}
+app.kubernetes.io/version: {{ .Chart.Version | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/cluster-warmer/templates/deployment.yaml
+++ b/charts/cluster-warmer/templates/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "app.fullname" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -10,6 +12,7 @@ spec:
     metadata:
       labels:
         app: {{ include "app.fullname" . }}
+        {{ include "snowplow.labels" $ | nindent 8 }}
     spec:
       priorityClassName: {{ include "app.fullname" . }}
       {{- if .Values.nodeSelector }}

--- a/charts/cluster-warmer/templates/deployment.yaml
+++ b/charts/cluster-warmer/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "app.fullname" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         app: {{ include "app.fullname" . }}
-        {{ include "snowplow.labels" $ | nindent 8 }}
+        {{- include "snowplow.labels" $ | nindent 8 }}
     spec:
       priorityClassName: {{ include "app.fullname" . }}
       {{- if .Values.nodeSelector }}

--- a/charts/cluster-warmer/templates/hpa.yaml
+++ b/charts/cluster-warmer/templates/hpa.yaml
@@ -2,6 +2,8 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "app.fullname" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/cluster-warmer/templates/hpa.yaml
+++ b/charts/cluster-warmer/templates/hpa.yaml
@@ -3,7 +3,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "app.fullname" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/cluster-warmer/templates/priorityclass.yaml
+++ b/charts/cluster-warmer/templates/priorityclass.yaml
@@ -3,6 +3,6 @@ kind: PriorityClass
 metadata:
   name: {{ include "app.fullname" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 value: -1
 globalDefault: false

--- a/charts/cluster-warmer/templates/priorityclass.yaml
+++ b/charts/cluster-warmer/templates/priorityclass.yaml
@@ -2,5 +2,7 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ include "app.fullname" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 value: -1
 globalDefault: false

--- a/charts/cluster-warmer/values.yaml
+++ b/charts/cluster-warmer/values.yaml
@@ -1,3 +1,7 @@
+global:
+  # global labels will be applied to all resources deployed by the chart
+  labels: {}
+
 # -- Overrides the full-name given to the deployment resources (default: .Release.Name)
 fullnameOverride: ""
 

--- a/charts/cron-job/Chart.yaml
+++ b/charts/cron-job/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cron-job
 description: A Helm Chart to deploy an arbitrary container as a cron job.
-version: 0.6.0
+version: 0.7.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/cron-job/README.md
+++ b/charts/cron-job/README.md
@@ -38,6 +38,7 @@ helm delete cron-job
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | global.cloud | string | `""` | Cloud specific bindings (options: aws, gcp, azure) |
+| global.labels | object | `{}` | Global labels deployed to all resources deployed by the chart |
 | fullnameOverride | string | `""` | Overrides the full-name given to the deployment resources (default: .Release.Name) |
 | schedule | string | `"*/1 * * * *"` |  |
 | concurrencyPolicy | string | `"Forbid"` |  |

--- a/charts/cron-job/templates/_helpers.tpl
+++ b/charts/cron-job/templates/_helpers.tpl
@@ -14,3 +14,24 @@ If release name contains chart name it will be used as a full name.
 {{- define "app.secret.fullname" -}}
 {{ include "app.fullname" . }}-secret
 {{- end -}}
+
+{{/*
+Create chart name and version to use as chart label.
+*/}}
+{{- define "cron.job.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Snowplow labels
+*/}}
+{{- define "snowplow.labels" -}}
+{{- with .Values.global.labels -}}
+{{ toYaml . }}
+{{ end -}}
+helm.sh/chart: {{ include "cron.job.chart" . }}
+{{- if .Chart.Version }}
+app.kubernetes.io/version: {{ .Chart.Version | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/cron-job/templates/configmaps.yaml
+++ b/charts/cron-job/templates/configmaps.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ $v.name }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 binaryData:
   {{- range $f := $v.files }}
   {{- if $f.contentsB64 }}

--- a/charts/cron-job/templates/configmaps.yaml
+++ b/charts/cron-job/templates/configmaps.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: {{ $v.name }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 binaryData:
   {{- range $f := $v.files }}
   {{- if $f.contentsB64 }}

--- a/charts/cron-job/templates/deployment.yaml
+++ b/charts/cron-job/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       template:
         metadata:
           labels:
-            {{ include "snowplow.labels" $ | nindent 8 }}
+            {{ include "snowplow.labels" $ | nindent 12 }}
             app: {{ include "app.fullname" . }}
             {{- if eq .Values.global.cloud "azure" }}
             azure.workload.identity/use: "true"

--- a/charts/cron-job/templates/deployment.yaml
+++ b/charts/cron-job/templates/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "app.fullname" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 spec:
   schedule: "{{ .Values.schedule }}"
   concurrencyPolicy: "{{ .Values.concurrencyPolicy }}"
@@ -13,6 +15,7 @@ spec:
       template:
         metadata:
           labels:
+            {{ include "snowplow.labels" $ | nindent 8 }}
             app: {{ include "app.fullname" . }}
             {{- if eq .Values.global.cloud "azure" }}
             azure.workload.identity/use: "true"

--- a/charts/cron-job/templates/deployment.yaml
+++ b/charts/cron-job/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: {{ include "app.fullname" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 spec:
   schedule: "{{ .Values.schedule }}"
   concurrencyPolicy: "{{ .Values.concurrencyPolicy }}"
@@ -15,7 +15,7 @@ spec:
       template:
         metadata:
           labels:
-            {{ include "snowplow.labels" $ | nindent 12 }}
+            {{- include "snowplow.labels" $ | nindent 12 }}
             app: {{ include "app.fullname" . }}
             {{- if eq .Values.global.cloud "azure" }}
             azure.workload.identity/use: "true"

--- a/charts/cron-job/templates/secrets.yaml
+++ b/charts/cron-job/templates/secrets.yaml
@@ -4,6 +4,8 @@ kind: Secret
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ include "app.secret.fullname" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 type: Opaque
 data:
   {{- range $k, $v := .Values.config.secrets }}

--- a/charts/cron-job/templates/secrets.yaml
+++ b/charts/cron-job/templates/secrets.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ include "app.secret.fullname" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 type: Opaque
 data:
   {{- range $k, $v := .Values.config.secrets }}

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -2,6 +2,9 @@ global:
   # -- Cloud specific bindings (options: aws, gcp, azure)
   cloud: ""
 
+  # global labels will be applied to all resources deployed by the chart
+  labels: {}
+
 # -- Overrides the full-name given to the deployment resources (default: .Release.Name)
 fullnameOverride: ""
 

--- a/charts/daemonset/Chart.yaml
+++ b/charts/daemonset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: daemonset
 description: A Helm Chart to deploy an arbitrary container as a daemonset.
-version: 0.3.2
+version: 0.4.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/daemonset/README.md
+++ b/charts/daemonset/README.md
@@ -51,6 +51,7 @@ helm delete daemonset
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | global.cloud | string | `""` | Cloud specific bindings (options: aws, gcp, azure) |
+| global.labels | object | `{}` | Global labels deployed to all resources deployed by the chart |
 | fullnameOverride | string | `""` | Overrides the full-name given to the deployment resources (default: .Release.Name) |
 | image.repository | string | `"nginx"` |  |
 | image.tag | string | `"latest"` |  |

--- a/charts/daemonset/templates/_helpers.tpl
+++ b/charts/daemonset/templates/_helpers.tpl
@@ -14,3 +14,24 @@ If release name contains chart name it will be used as a full name.
 {{- define "app.secret.fullname" -}}
 {{ include "app.fullname" . }}-secret
 {{- end -}}
+
+{{/*
+Create chart name and version to use as chart label.
+*/}}
+{{- define "daemonset.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Snowplow labels
+*/}}
+{{- define "snowplow.labels" -}}
+{{- with .Values.global.labels -}}
+{{ toYaml . }}
+{{ end -}}
+helm.sh/chart: {{ include "daemonset.chart" . }}
+{{- if .Chart.Version }}
+app.kubernetes.io/version: {{ .Chart.Version | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/daemonset/templates/cluster_role.yaml
+++ b/charts/daemonset/templates/cluster_role.yaml
@@ -4,7 +4,7 @@ kind: ClusterRole
 metadata:
   name: {{ include "app.fullname" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 rules:
 {{- toYaml $.Values.clusterrole.rules  | nindent 2 }}
 ---

--- a/charts/daemonset/templates/cluster_role.yaml
+++ b/charts/daemonset/templates/cluster_role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "app.fullname" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 rules:
 {{- toYaml $.Values.clusterrole.rules  | nindent 2 }}
 ---

--- a/charts/daemonset/templates/cluster_role_binding.yaml
+++ b/charts/daemonset/templates/cluster_role_binding.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "app.fullname" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/daemonset/templates/cluster_role_binding.yaml
+++ b/charts/daemonset/templates/cluster_role_binding.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "app.fullname" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/daemonset/templates/configmaps.yaml
+++ b/charts/daemonset/templates/configmaps.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ $v.name }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 binaryData:
   {{- range $f := $v.files }}
   {{- if $f.contentsB64 }}

--- a/charts/daemonset/templates/configmaps.yaml
+++ b/charts/daemonset/templates/configmaps.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: {{ $v.name }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 binaryData:
   {{- range $f := $v.files }}
   {{- if $f.contentsB64 }}

--- a/charts/daemonset/templates/daemonset.yaml
+++ b/charts/daemonset/templates/daemonset.yaml
@@ -3,7 +3,7 @@ kind: DaemonSet
 metadata:
   name: {{ include "app.fullname" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       labels:
-        {{ include "snowplow.labels" $ | nindent 8 }}
+        {{- include "snowplow.labels" $ | nindent 8 }}
         app: {{ include "app.fullname" . }}
         {{- if eq .Values.global.cloud "azure" }}
         azure.workload.identity/use: "true"

--- a/charts/daemonset/templates/daemonset.yaml
+++ b/charts/daemonset/templates/daemonset.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "app.fullname" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -9,6 +11,7 @@ spec:
   template:
     metadata:
       labels:
+        {{ include "snowplow.labels" $ | nindent 8 }}
         app: {{ include "app.fullname" . }}
         {{- if eq .Values.global.cloud "azure" }}
         azure.workload.identity/use: "true"

--- a/charts/daemonset/templates/secrets.yaml
+++ b/charts/daemonset/templates/secrets.yaml
@@ -4,6 +4,8 @@ kind: Secret
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ include "app.secret.fullname" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 type: Opaque
 data:
   {{- range $k, $v := .Values.config.secrets }}

--- a/charts/daemonset/templates/secrets.yaml
+++ b/charts/daemonset/templates/secrets.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ include "app.secret.fullname" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 type: Opaque
 data:
   {{- range $k, $v := .Values.config.secrets }}

--- a/charts/daemonset/templates/service.yaml
+++ b/charts/daemonset/templates/service.yaml
@@ -4,9 +4,7 @@ kind: Service
 metadata:
   name: {{ include "app.fullname" . }}
   labels:
-  {{- range $k, $v := .Values.service.labels }}
-    {{ $k }}: {{ $v }}
-  {{- end }}
+    {{ include "snowplow.labels" $ | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   selector:

--- a/charts/daemonset/templates/service.yaml
+++ b/charts/daemonset/templates/service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ include "app.fullname" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   selector:

--- a/charts/daemonset/values.yaml
+++ b/charts/daemonset/values.yaml
@@ -2,6 +2,9 @@ global:
   # -- Cloud specific bindings (options: aws, gcp, azure)
   cloud: ""
 
+  # global labels will be applied to all resources deployed by the chart
+  labels: {}
+
 # -- Overrides the full-name given to the deployment resources (default: .Release.Name)
 fullnameOverride: ""
 

--- a/charts/priority-class/Chart.yaml
+++ b/charts/priority-class/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: priority-class
 description: A Helm Chart to setup priority classes for all tiers
-version: 0.1.0
+version: 0.2.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/priority-class/README.md
+++ b/charts/priority-class/README.md
@@ -40,3 +40,4 @@ helm delete priority-class
 |-----|------|---------|-------------|
 | nameOverride | string | `""` | Overrides the name given to the deployment resources (default: .Release.Name) |
 | fullnameOverride | string | `""` | Overrides the full-name given to the deployment resources (default: .Release.Name) |
+| labels | object | `{}` | labels deployed to all priority classes deployed by the chart |

--- a/charts/priority-class/templates/_helpers.tpl
+++ b/charts/priority-class/templates/_helpers.tpl
@@ -34,6 +34,9 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "priority-class.labels" -}}
+{{- with .Values.labels -}}
+{{ toYaml . }}
+{{ end -}}
 helm.sh/chart: {{ include "priority-class.chart" . }}
 {{ include "priority-class.selectorLabels" . }}
 {{- if .Chart.AppVersion }}

--- a/charts/priority-class/values.yaml
+++ b/charts/priority-class/values.yaml
@@ -2,6 +2,8 @@
 nameOverride: ""
 # -- Overrides the full-name given to the deployment resources (default: .Release.Name)
 fullnameOverride: ""
+# -- Labels will be applied to each priority class
+labels: {}
 
 priorityClasses:
   - name: critical

--- a/charts/snowplow-iglu-server/Chart.yaml
+++ b/charts/snowplow-iglu-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: snowplow-iglu-server
 description: A Helm Chart to deploy the Snowplow Iglu Server project
-version: 0.6.0
+version: 0.7.0
 appVersion: "0.12.0"
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts

--- a/charts/snowplow-iglu-server/README.md
+++ b/charts/snowplow-iglu-server/README.md
@@ -146,6 +146,7 @@ You will need to fill these targeted fields:
 | dockerconfigjson.username | string | `""` | Username for the private repository |
 | fullnameOverride | string | `""` | Overrides the full-name given to the deployment resources (default: .Release.Name) |
 | global.cloud | string | `""` | Cloud specific bindings (options: aws, gcp, azure) |
+| global.labels | object | `{}` | Global labels deployed to all resources deployed by the chart |
 | service.annotations | object | `{}` | Map of annotations to add to the service |
 | service.aws.targetGroupARN | string | `""` | EC2 TargetGroup ARN to bind the service onto |
 | service.config.database.dbname | string | `""` | Postgres database name |

--- a/charts/snowplow-iglu-server/templates/_helpers.tpl
+++ b/charts/snowplow-iglu-server/templates/_helpers.tpl
@@ -60,3 +60,24 @@ Define default values for required values.
 {{- define "iglu.service.config.checksum" -}}
 {{- printf "%s-%s-%s" (include "iglu.service.config.superApiKey" .) .Values.service.config.database.secrets.password .Values.service.config.database.secrets.username | sha256sum -}}
 {{- end -}}
+
+{{/*
+Create chart name and version to use as chart label.
+*/}}
+{{- define "iglu.service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Snowplow labels
+*/}}
+{{- define "snowplow.labels" -}}
+{{- with .Values.global.labels -}}
+{{ toYaml . }}
+{{ end -}}
+helm.sh/chart: {{ include "iglu.service.chart" . }}
+{{- if .Chart.Version }}
+app.kubernetes.io/version: {{ .Chart.Version | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/snowplow-iglu-server/templates/certificate.yaml
+++ b/charts/snowplow-iglu-server/templates/certificate.yaml
@@ -5,6 +5,8 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ required "A valid hostname is required!" .hostname }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 spec:
   secretName: {{ .hostname }}-tls
   issuerRef:

--- a/charts/snowplow-iglu-server/templates/certificate.yaml
+++ b/charts/snowplow-iglu-server/templates/certificate.yaml
@@ -6,7 +6,7 @@ kind: Certificate
 metadata:
   name: {{ required "A valid hostname is required!" .hostname }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 spec:
   secretName: {{ .hostname }}-tls
   issuerRef:

--- a/charts/snowplow-iglu-server/templates/cloudsqlproxy-deployment.yaml
+++ b/charts/snowplow-iglu-server/templates/cloudsqlproxy-deployment.yaml
@@ -4,16 +4,16 @@ kind: Deployment
 metadata:
   name: {{ include "iglu.cloudsqlproxy.name" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 spec:
   selector:
     matchLabels:
       app: {{ include "iglu.cloudsqlproxy.name" . }}
-      {{ include "snowplow.labels" $ | nindent 8 }}
   template:
     metadata:
       labels:
         app: {{ include "iglu.cloudsqlproxy.name" . }}
+        {{- include "snowplow.labels" $ | nindent 8 }}
     spec:
       {{- if .Values.cloudserviceaccount.deploy }}
       serviceAccountName: {{ .Values.cloudserviceaccount.name }}

--- a/charts/snowplow-iglu-server/templates/cloudsqlproxy-deployment.yaml
+++ b/charts/snowplow-iglu-server/templates/cloudsqlproxy-deployment.yaml
@@ -3,10 +3,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "iglu.cloudsqlproxy.name" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 spec:
   selector:
     matchLabels:
       app: {{ include "iglu.cloudsqlproxy.name" . }}
+      {{ include "snowplow.labels" $ | nindent 8 }}
   template:
     metadata:
       labels:

--- a/charts/snowplow-iglu-server/templates/cloudsqlproxy-service.yaml
+++ b/charts/snowplow-iglu-server/templates/cloudsqlproxy-service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "iglu.cloudsqlproxy.name" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 spec:
   type: NodePort
   selector:

--- a/charts/snowplow-iglu-server/templates/cloudsqlproxy-service.yaml
+++ b/charts/snowplow-iglu-server/templates/cloudsqlproxy-service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ include "iglu.cloudsqlproxy.name" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 spec:
   type: NodePort
   selector:

--- a/charts/snowplow-iglu-server/templates/iglu-deployment.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "iglu.app.name" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -10,6 +12,7 @@ spec:
     metadata:
       labels:
         app: {{ include "iglu.app.name" . }}
+        {{ include "snowplow.labels" $ | nindent 8 }}
       annotations:
         checksum/config: "{{ include "iglu.service.config.checksum" . }}"
         {{- if ne .Values.service.config.hoconBase64 "" }}

--- a/charts/snowplow-iglu-server/templates/iglu-deployment.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "iglu.app.name" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         app: {{ include "iglu.app.name" . }}
-        {{ include "snowplow.labels" $ | nindent 8 }}
+        {{- include "snowplow.labels" $ | nindent 8 }}
       annotations:
         checksum/config: "{{ include "iglu.service.config.checksum" . }}"
         {{- if ne .Values.service.config.hoconBase64 "" }}

--- a/charts/snowplow-iglu-server/templates/iglu-hoconconfigmap.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-hoconconfigmap.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "iglu.app.config.name" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 binaryData:
   config.hocon: {{ .Values.service.config.hoconBase64 }}
 {{- end }}

--- a/charts/snowplow-iglu-server/templates/iglu-hoconconfigmap.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-hoconconfigmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "iglu.app.config.name" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 binaryData:
   config.hocon: {{ .Values.service.config.hoconBase64 }}
 {{- end }}

--- a/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
@@ -4,6 +4,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "iglu.hooks.name" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed

--- a/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
@@ -5,7 +5,7 @@ kind: Job
 metadata:
   name: {{ include "iglu.hooks.name" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed

--- a/charts/snowplow-iglu-server/templates/iglu-hpa.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-hpa.yaml
@@ -2,6 +2,8 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "iglu.app.name" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/snowplow-iglu-server/templates/iglu-hpa.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-hpa.yaml
@@ -3,7 +3,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "iglu.app.name" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/snowplow-iglu-server/templates/iglu-ingress.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-ingress.yaml
@@ -4,6 +4,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "iglu.app.name" $ }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
   annotations:
   {{- if .annotations }}
     {{- toYaml .annotations | nindent 4 }}

--- a/charts/snowplow-iglu-server/templates/iglu-ingress.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-ingress.yaml
@@ -5,7 +5,7 @@ kind: Ingress
 metadata:
   name: {{ include "iglu.app.name" $ }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
   annotations:
   {{- if .annotations }}
     {{- toYaml .annotations | nindent 4 }}

--- a/charts/snowplow-iglu-server/templates/iglu-ipallowlist.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-ipallowlist.yaml
@@ -3,6 +3,8 @@ apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: {{ include "iglu.app.name" . }}-ipallowlist
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 spec:
   ipWhiteList:
     sourceRange:

--- a/charts/snowplow-iglu-server/templates/iglu-ipallowlist.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-ipallowlist.yaml
@@ -4,7 +4,7 @@ kind: Middleware
 metadata:
   name: {{ include "iglu.app.name" . }}-ipallowlist
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 spec:
   ipWhiteList:
     sourceRange:

--- a/charts/snowplow-iglu-server/templates/iglu-secret.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-secret.yaml
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ include "iglu.app.secret.name" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 type: Opaque
 data:
   CONFIG_FORCE_iglu_superApiKey: "{{ include "iglu.service.config.superApiKey" . | b64enc }}"

--- a/charts/snowplow-iglu-server/templates/iglu-secret.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-secret.yaml
@@ -4,7 +4,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ include "iglu.app.secret.name" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 type: Opaque
 data:
   CONFIG_FORCE_iglu_superApiKey: "{{ include "iglu.service.config.superApiKey" . | b64enc }}"

--- a/charts/snowplow-iglu-server/templates/iglu-service.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ include "iglu.app.name" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
   annotations:
   {{- if .Values.service.annotations }}
     {{- toYaml .Values.service.annotations | nindent 4 }}

--- a/charts/snowplow-iglu-server/templates/iglu-service.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "iglu.app.name" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
   annotations:
   {{- if .Values.service.annotations }}
     {{- toYaml .Values.service.annotations | nindent 4 }}

--- a/charts/snowplow-iglu-server/templates/iglu-targetgroupbinding.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-targetgroupbinding.yaml
@@ -3,6 +3,8 @@ apiVersion: elbv2.k8s.aws/v1beta1
 kind: TargetGroupBinding
 metadata:
   name: {{ include "iglu.app.name" . }}
+  labels:
+    {{ include "snowplow.labels" $ | nindent 4 }}
 spec:
   serviceRef:
     name: {{ include "iglu.app.name" . }}

--- a/charts/snowplow-iglu-server/templates/iglu-targetgroupbinding.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-targetgroupbinding.yaml
@@ -4,7 +4,7 @@ kind: TargetGroupBinding
 metadata:
   name: {{ include "iglu.app.name" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 spec:
   serviceRef:
     name: {{ include "iglu.app.name" . }}

--- a/charts/snowplow-iglu-server/values.yaml
+++ b/charts/snowplow-iglu-server/values.yaml
@@ -2,6 +2,9 @@ global:
   # -- Cloud specific bindings (options: aws, gcp, azure)
   cloud: ""
 
+  # global labels will be applied to all resources deployed by the chart
+  labels: {}
+
 # -- Overrides the full-name given to the deployment resources (default: .Release.Name)
 fullnameOverride: ""
 


### PR DESCRIPTION
This PR updates the following charts to add global labels to the resources deployed within the chart

- charts/snowplow-iglu-server
- charts/priority-class
- charts/daemonset
- charts/cron-job
- charts/cluster-warmer