### PR TITLE
charts/aws-otel-collector: Add kube state metrics collection (closes #190)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.71 (2024-08-23)
+---------------------------
+charts/aws-otel-collector add support for kube-state-metrics (closes #190)
+
 Version 0.1.70 (2024-08-15)
 ---------------------------
 charts/snowplow-iglu-server add global labels (closes #179)

--- a/charts/aws-otel-collector/Chart.yaml
+++ b/charts/aws-otel-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-otel-collector
 description: A Helm chart to deploy aws-otel-collector project
-version: 0.2.1
+version: 0.3.0
 appVersion: "v0.33.1"
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts

--- a/charts/aws-otel-collector/README.md
+++ b/charts/aws-otel-collector/README.md
@@ -44,6 +44,9 @@ helm delete aws-otel-collector --namespace kube-system
 | image.repository | string | `"public.ecr.aws/aws-observability/aws-otel-collector"` | Image to use for deploying |
 | image.tag | string | `"v0.33.1"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
+| kube_state_metrics_enabled | bool | `false` | Whether to collect kube-state-metrics |
+| performance_log_retention_in_days | int | `30` | The retention for performance log group |
+| prometheus_log_retention_in_days | int | `30` | The retention for prometheus log group|
 | resources.limits.cpu | string | `"200m"` |  |
 | resources.limits.memory | string | `"200Mi"` |  |
 | resources.requests.cpu | string | `"200m"` |  |
@@ -51,3 +54,4 @@ helm delete aws-otel-collector --namespace kube-system
 | serviceAccount.create | bool | `true` | Whether to create a service account or not |
 | serviceAccount.name | string | `""` | The name of the service account to create or use |
 | serviceAccount.annotations | object | `{}` | Optional annotations to be applied to service account |
+| tags | object | `{}`| Tags to apply to log groups |

--- a/charts/aws-otel-collector/templates/configmap.yaml
+++ b/charts/aws-otel-collector/templates/configmap.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "aws-otel-collector.labels" . | nindent 4 }}
 data:
   otel-agent-config: |
+{{- if not .Values.kube_state_metrics_enabled }}
     extensions:
       health_check:
 
@@ -22,10 +23,15 @@ data:
         namespace: ContainerInsights
         log_group_name: '/aws/containerinsights/{ClusterName}/performance'
         log_stream_name: '{NodeName}'
+        log_retention: {{ .Values.performance_log_retention_in_days }}
         resource_to_telemetry_conversion:
           enabled: true
         dimension_rollup_option: NoDimensionRollup
         parse_json_encoded_attr_values: [Sources, kubernetes]
+        {{- with .Values.tags }}
+        tags:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         metric_declarations:
           - dimensions: [[PodName, Namespace, ClusterName]]
             metric_name_selectors:
@@ -51,3 +57,102 @@ data:
           exporters: [awsemf]
 
       extensions: [health_check]
+{{- else }}
+    extensions:
+      health_check:
+
+    receivers:
+      awscontainerinsightreceiver:
+        add_full_pod_name_metric_label: true
+      prometheus:
+        config:
+          global:
+            scrape_interval: 1m
+            scrape_timeout: 10s
+          scrape_configs:
+            - job_name: kube-state-metrics
+              honor_timestamps: true
+              scrape_interval: 1m
+              scrape_timeout: 1m
+              metrics_path: /metrics
+              scheme: http
+              static_configs:
+              - targets:
+                - prometheus-kube-state-metrics.monitoring.svc.cluster.local:8080
+
+    processors:
+      batch/metrics:
+        timeout: 60s
+      resourcedetection/ec2:
+        detectors: [ env ]
+        timeout: 2s
+        override: false
+      resource:
+        attributes:
+          - key: TaskId
+            from_attribute: service.name
+            action: insert
+          - key: receiver
+            value: "prometheus"
+            action: insert
+
+    exporters:
+      awsemf:
+        namespace: ContainerInsights
+        log_group_name: '/aws/containerinsights/{ClusterName}/performance'
+        log_stream_name: '{NodeName}'
+        log_retention: {{ .Values.performance_log_retention_in_days }}
+        resource_to_telemetry_conversion:
+          enabled: true
+        dimension_rollup_option: NoDimensionRollup
+        parse_json_encoded_attr_values: [Sources, kubernetes]
+        {{- with .Values.tags }}
+        tags:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        metric_declarations:
+          - dimensions: [[PodName, Namespace, ClusterName]]
+            metric_name_selectors:
+              - pod_cpu_utilization
+              - pod_memory_utilization
+              - pod_number_of_running_containers
+              - pod_number_of_container_restarts
+          - dimensions: [[FullPodName, Namespace, ClusterName]]
+            metric_name_selectors:
+              - pod_cpu_utilization
+              - pod_memory_utilization
+
+      awsemf/prometheus:
+        namespace: ContainerInsights/Prometheus
+        log_group_name: "/aws/containerinsights/{TaskId}/prometheus"
+        log_stream_name: "{TaskId}"
+        log_retention: {{ .Values.prometheus_log_retention_in_days }}
+        resource_to_telemetry_conversion:
+          enabled: true
+        dimension_rollup_option: NoDimensionRollup
+        {{- with .Values.tags }}
+        tags:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        metric_declarations:
+        - dimensions: [[ namespace, deployment ]]
+          metric_name_selectors:
+            - "^kube_deployment_status_replicas_ready$"
+          label_matchers:
+            - label_names:
+                - service.name
+              regex: ^kube-state-metrics$
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [awscontainerinsightreceiver]
+          processors: [batch/metrics]
+          exporters: [awsemf]
+        metrics/prometheus:
+          receivers: [prometheus]
+          processors: [resourcedetection/ec2, resource]
+          exporters: [awsemf/prometheus]
+
+      extensions: [health_check]
+{{- end }}

--- a/charts/aws-otel-collector/templates/daemonset.yaml
+++ b/charts/aws-otel-collector/templates/daemonset.yaml
@@ -10,6 +10,8 @@ spec:
       {{- include "aws-otel-collector.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "aws-otel-collector.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/aws-otel-collector/values.yaml
+++ b/charts/aws-otel-collector/values.yaml
@@ -24,3 +24,15 @@ serviceAccount:
   name: ""
   # -- Optional annotations to be applied to service account
   annotations: {}
+
+# -- Determines whether to enable kube state metrics collection with Prometheus
+kube_state_metrics_enabled: false
+
+# -- Set the retention for log group /aws/containerinsights/{ClusterName}/performance
+performance_log_retention_in_days: 30
+
+# -- Set the retention for log group /aws/containerinsights/{TaskId}/prometheus
+prometheus_log_retention_in_days: 30
+
+# -- Set tags to log groups created by otel collector awsemfexporter
+tags: {}


### PR DESCRIPTION
This PR adds in log_retention, log group tags, and enablement to export kube state metrics from prometheus to cloudwatch, specifically the `kube_deployment_status_replicas` metric. Will only capture kube state metrics if set through `kube_state_metrics_enabled` flag