### PR TITLE
charts/service-deployment add tolerations and topologySpreadConstraints

### DIFF
--- a/charts/service-deployment/Chart.yaml
+++ b/charts/service-deployment/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: service-deployment
 description: A Helm Chart to setup a generic deployment with optional service/hpa bindings
-version: 0.19.1
+version: 0.20.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/service-deployment/README.md
+++ b/charts/service-deployment/README.md
@@ -107,3 +107,5 @@ helm delete service-deployment
 | service.protocol | string | `"TCP"` | Protocol that the service leverages (note: TCP or UDP) |
 | service.targetPort | int | `80` | The Target Port that the actual application is being exposed on |
 | terminationGracePeriodSeconds | int | `60` | Grace period for termination of the service |
+| tolerations | list |`[]` | Tolerations labels for pod assignment with matching taints |
+| topologySpreadConstraints | object | `{}` | Topology Spread Constraints for pod assignment |

--- a/charts/service-deployment/templates/certificate.yaml
+++ b/charts/service-deployment/templates/certificate.yaml
@@ -6,7 +6,7 @@ kind: Certificate
 metadata:
   name: {{ required "A valid hostname is required!" .hostname }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 spec:
   secretName: {{ .hostname }}-tls
   issuerRef:

--- a/charts/service-deployment/templates/configmaps.yaml
+++ b/charts/service-deployment/templates/configmaps.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: {{ $v.name }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 binaryData:
   {{- range $f := $v.files }}
   {{- if $f.contentsB64 }}

--- a/charts/service-deployment/templates/deployment.yaml
+++ b/charts/service-deployment/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: {{ .Values.deployment.kind }}
 metadata:
   name: {{ include "app.fullname" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 spec:
   {{- if .Values.deployment.scaleToZero }}
   replicas: 0
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        {{ include "snowplow.labels" $ | nindent 8 }}
+        {{- include "snowplow.labels" $ | nindent 8 }}
         {{- if .Values.deployment.podLabels }}
         {{- toYaml .Values.deployment.podLabels | nindent 8 }}
         {{- end }}
@@ -83,6 +83,15 @@ spec:
       {{- if .Values.affinity }}
       affinity:
       {{- toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
 
       containers:

--- a/charts/service-deployment/templates/hpa.yaml
+++ b/charts/service-deployment/templates/hpa.yaml
@@ -4,7 +4,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "app.fullname" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/service-deployment/templates/ingress.yaml
+++ b/charts/service-deployment/templates/ingress.yaml
@@ -5,7 +5,7 @@ kind: Ingress
 metadata:
   name: {{ required "A valid hostname is required!" .hostname }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
   annotations:
   {{- if .annotations }}
     {{- toYaml .annotations | nindent 4 }}

--- a/charts/service-deployment/templates/ipallowlist.yaml
+++ b/charts/service-deployment/templates/ipallowlist.yaml
@@ -4,7 +4,7 @@ kind: Middleware
 metadata:
   name: {{ include "app.fullname" . }}-ipallowlist
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 spec:
   ipWhiteList:
     sourceRange:

--- a/charts/service-deployment/templates/pvc.yaml
+++ b/charts/service-deployment/templates/pvc.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ toYaml .Values.persistentVolume.annotations | indent 4 }}
   {{- end }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
     {{- with .Values.persistentVolume.labels }}
        {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/service-deployment/templates/secrets.yaml
+++ b/charts/service-deployment/templates/secrets.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ include "app.secret.fullname" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 type: Opaque
 data:
   {{- range $k, $v := .Values.config.secrets }}

--- a/charts/service-deployment/templates/service.yaml
+++ b/charts/service-deployment/templates/service.yaml
@@ -12,7 +12,7 @@ metadata:
     cloud.google.com/neg: '{"exposed_ports": {"{{ .Values.service.port }}":{"name": "{{ include "service.gcp.networkEndpointGroupName" . }}"}}}'
   {{- end }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 spec:
   type: NodePort
   selector:

--- a/charts/service-deployment/templates/targetgroupbinding.yaml
+++ b/charts/service-deployment/templates/targetgroupbinding.yaml
@@ -5,7 +5,7 @@ kind: TargetGroupBinding
 metadata:
   name: {{ include "app.fullname" . }}
   labels:
-    {{ include "snowplow.labels" $ | nindent 4 }}
+    {{- include "snowplow.labels" $ | nindent 4 }}
 spec:
   serviceRef:
     name: {{ include "app.fullname" . }}

--- a/charts/service-deployment/values.yaml
+++ b/charts/service-deployment/values.yaml
@@ -176,6 +176,16 @@ deployment:
 # -- PriorityClassName for pods
 priorityClassName: ""
 
+# -- Allow the scheduler to schedule pods with matching taints
+#
+# more details here: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+tolerations: []
+
+# -- topologySpreadConstraints control how Pods are  spread across your cluster among failure-domains such as regions, zones, nodes, and other user-defined topology domains.
+#
+# more details here: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+topologySpreadConstraints: {}
+
 # -- Affinity supports podAffinity, podAntiAffinity, or nodeAffinity
 affinity: {}
 # podAffinity:


### PR DESCRIPTION
This PR updates service-deployment helm chart to supprt

- `topologySpreadConstraints` - https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
- `tolerations` - https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/

Also updates the global labels to remove leading empty space.

Before

```
# Source: service-deployment/templates/hpa.yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: sd
  labels:

    helm.sh/chart: service-deployment-0.20.0
    app.kubernetes.io/version: "0.20.0"
    app.kubernetes.io/managed-by: Helm
spec:
```

After

```
# Source: service-deployment/templates/hpa.yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: sd
  labels:
    helm.sh/chart: service-deployment-0.20.0
    app.kubernetes.io/version: "0.20.0"
    app.kubernetes.io/managed-by: Helm
```