### PR TITLE
Create Helm Hook Job for DB users and permissions (closes #196)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.72 (2024-08-29)
+---------------------------
+charts/snowplow-iglu-server: Create Helm Hook Job for DB users and permissions (closes #196)
+
 Version 0.1.71 (2024-08-23)
 ---------------------------
 charts/aws-otel-collector add support for kube-state-metrics (closes #190)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-Version 0.1.74 (2024-08-30)
+Version 0.1.75 (2024-08-30)
 ---------------------------
 charts/snowplow-iglu-server: Create Helm Hook Job for DB users and permissions (closes #196)
 

--- a/charts/snowplow-iglu-server/Chart.yaml
+++ b/charts/snowplow-iglu-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: snowplow-iglu-server
 description: A Helm Chart to deploy the Snowplow Iglu Server project
-version: 0.7.0
+version: 0.8.0
 appVersion: "0.12.0"
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts

--- a/charts/snowplow-iglu-server/README.md
+++ b/charts/snowplow-iglu-server/README.md
@@ -118,7 +118,7 @@ You will need to fill these targeted fields:
 
 ### Azure (AKS) settings
 
-When `dev_db` is `true` and  `cloud` is `azure` the hook job `-dev-db-user-setup` will be initiated
+When `dev_db` is `true` the hook job `-dev-db-user-setup` will be initiated
 
 ### AWS (EKS) settings
 

--- a/charts/snowplow-iglu-server/README.md
+++ b/charts/snowplow-iglu-server/README.md
@@ -118,6 +118,8 @@ You will need to fill these targeted fields:
 
 ### Azure (AKS) settings
 
+When `dev_db` is `true` and  `cloud` is `azure` the hook job `-dev-db-user-setup` will be initiated
+
 ### AWS (EKS) settings
 
 #### TargetGroup binding
@@ -163,6 +165,9 @@ You will need to fill these targeted fields:
 | service.config.repoServer.hsts.enable | bool | `true` | Whether to enable sending HSTS headers (>=0.12.0) |
 | service.config.secrets.superApiKey | string | `""` | Lowercase uuidv4 to use as admin apikey of the service (default: auto-generated) |
 | service.deploySetupHooks | bool | `true` | Whether to run the post-deploy setup hooks |
+| service.azure.dev_db | bool | `false` | Whether we deploy for dev db in Azure |
+| service.azure.secrets.admin_username | string | `""` | The admin username that will be used for the psql command |
+| service.azure.secrets.admin_password | string | `""` | The admin password that will be used for the psql command |
 | service.gcp.deployProxy | bool | `false` | Whether to use CloudSQL Proxy (note: requires GCP service account to be attached) |
 | service.gcp.networkEndpointGroupName | string | `""` | Name of the Network Endpoint Group to bind onto |
 | service.gcp.proxy.image.isRepositoryPublic | bool | `true` | Whether the repository is public |

--- a/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.service.deploySetupHooks }}
 {{- if eq (include "iglu.service.config.database.type" .) "postgres" }}
+
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -9,6 +10,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-weight": "2"  
 spec:
   template:
     metadata:
@@ -17,12 +19,10 @@ spec:
       restartPolicy: Never
       containers:
       - name: {{ include "iglu.hooks.name" . }}
-        image: {{ .Values.service.image.repository}}:{{ .Values.service.image.tag}}
+        image: {{ .Values.service.image.repository}}:{{ .Values.service.image.tag }}
         imagePullPolicy: Always
-
         args:
         - "setup"
-
         env:
         {{- range $k, $v := .Values.service.config.env }}
         - name: "{{ $k }}"
@@ -31,21 +31,82 @@ spec:
         - name: "JDK_JAVA_OPTIONS"
           value: "-Dconfig.override_with_env_vars=true"
         {{- if .Values.service.gcp.deployProxy }}
-        - name : "CONFIG_FORCE_iglu_database_host"
+        - name: "CONFIG_FORCE_iglu_database_host"
           value: {{ include "iglu.cloudsqlproxy.host" . }}
-        - name : "CONFIG_FORCE_iglu_database_port"
+        - name: "CONFIG_FORCE_iglu_database_port"
           value: "{{ .Values.service.gcp.proxy.port }}"
         {{- else }}
-        - name : "CONFIG_FORCE_iglu_database_host"
+        - name: "CONFIG_FORCE_iglu_database_host"
           value: "{{ .Values.service.config.database.host }}"
-        - name : "CONFIG_FORCE_iglu_database_port"
+        - name: "CONFIG_FORCE_iglu_database_port"
           value: "{{ .Values.service.config.database.port }}"
         {{- end }}
-        - name : "CONFIG_FORCE_iglu_database_dbname"
+        - name: "CONFIG_FORCE_iglu_database_dbname"
           value: "{{ .Values.service.config.database.dbname }}"
-
         envFrom:
         - secretRef:
             name: {{ include "iglu.app.secret.name" . }}
+
+{{- if and (eq .Values.service.azure.dev_db "true") (eq .Values.global.cloud "azure") }}
+
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "iglu.hooks.name" . }}-db-dev-user-setup
+  labels:
+    {{- include "snowplow.labels" $ | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-weight": "1" 
+spec:
+  template:
+    metadata:
+      name: {{ include "iglu.hooks.name" . }}-db-dev-user-setup
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: {{ include "iglu.hooks.name" . }}-db-dev-user-setup
+        image: postgres:15
+        imagePullPolicy: Always
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            export PGPASSWORD="${CONFIG_FORCE_iglu_database_admin_password}" 
+            psql -h "${CONFIG_FORCE_iglu_database_host}" \
+                 -U "${CONFIG_FORCE_iglu_database_admin_username}" \
+                 -d "${CONFIG_FORCE_iglu_database_dbname}" \
+                 -c "CREATE USER ${CONFIG_FORCE_iglu_database_dev_username} WITH PASSWORD '${CONFIG_FORCE_iglu_database_dev_password}';" && echo "OK"
+            psql -h "${CONFIG_FORCE_iglu_database_host}" \
+                 -U "${CONFIG_FORCE_iglu_database_admin_username}" \
+                 -d "${CONFIG_FORCE_iglu_database_dbname}" \
+                 -c "GRANT ALL PRIVILEGES ON DATABASE ${CONFIG_FORCE_iglu_database_dbname} TO ${CONFIG_FORCE_iglu_database_dev_username};" && echo "OK"
+            psql -h "${CONFIG_FORCE_iglu_database_host}" \
+                 -U "${CONFIG_FORCE_iglu_database_admin_username}" \
+                 -d "${CONFIG_FORCE_iglu_database_dbname}" \
+                 -c "GRANT USAGE, CREATE ON SCHEMA public TO ${CONFIG_FORCE_iglu_database_dev_username};" && echo "OK"
+        env:
+        - name: "CONFIG_FORCE_Test"
+          value: "{{ .Values.service.azure.dev_db  }}"
+        - name: "CONFIG_FORCE_iglu_database_admin_password"
+          value: "{{ .Values.service.azure.secrets.admin_password }}"
+        - name: "CONFIG_FORCE_iglu_database_admin_username"
+          value: "{{ .Values.service.azure.secrets.admin_username }}"
+        - name: "CONFIG_FORCE_iglu_database_dev_username"
+          value: "{{ .Values.service.config.database.secrets.username }}"
+        - name: "CONFIG_FORCE_iglu_database_dev_password"
+          value: "{{ .Values.service.config.database.secrets.password }}"
+        - name: "CONFIG_FORCE_iglu_database_host"
+          value: "{{ .Values.service.config.database.host }}"
+        - name: "CONFIG_FORCE_iglu_database_dbname"
+          value: "{{ .Values.service.config.database.dbname }}"
+        - name: "CONFIG_FORCE_iglu_database_port"
+          value: "{{ .Values.service.gcp.proxy.port }}"
+        envFrom:
+        - secretRef:
+            name: {{ include "iglu.app.secret.name" . }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
@@ -47,7 +47,7 @@ spec:
         - secretRef:
             name: {{ include "iglu.app.secret.name" . }}
 
-{{- if eq .Values.service.azure.dev_db "true" }}
+{{- if .Values.service.azure.dev_db }}
 
 ---
 

--- a/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
@@ -47,7 +47,7 @@ spec:
         - secretRef:
             name: {{ include "iglu.app.secret.name" . }}
 
-{{- if and (eq .Values.service.azure.dev_db "true") (eq .Values.global.cloud "azure") }}
+{{- if eq .Values.service.azure.dev_db "true" }}
 
 ---
 

--- a/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
@@ -69,7 +69,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: {{ include "iglu.hooks.name" . }}-dev-db-user-setup
-        image: postgres:15
+        image: postgres:15-alpine
         imagePullPolicy: Always
         command: ["/bin/bash", "-c"]
         args:

--- a/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
@@ -88,8 +88,6 @@ spec:
                  -d "${CONFIG_FORCE_iglu_database_dbname}" \
                  -c "GRANT USAGE, CREATE ON SCHEMA public TO ${CONFIG_FORCE_iglu_database_dev_username};" && echo "OK"
         env:
-        - name: "CONFIG_FORCE_Test"
-          value: "{{ .Values.service.azure.dev_db  }}"
         - name: "CONFIG_FORCE_iglu_database_admin_password"
           value: "{{ .Values.service.azure.secrets.admin_password }}"
         - name: "CONFIG_FORCE_iglu_database_admin_username"

--- a/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
@@ -58,7 +58,7 @@ metadata:
   labels:
     {{- include "snowplow.labels" $ | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
     "helm.sh/hook-weight": "1" 
 spec:

--- a/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
@@ -54,7 +54,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "iglu.hooks.name" . }}-db-dev-user-setup
+  name: {{ include "iglu.hooks.name" . }}-dev-db-user-setup
   labels:
     {{- include "snowplow.labels" $ | nindent 4 }}
   annotations:
@@ -64,11 +64,11 @@ metadata:
 spec:
   template:
     metadata:
-      name: {{ include "iglu.hooks.name" . }}-db-dev-user-setup
+      name: {{ include "iglu.hooks.name" . }}-dev-db-user-setup
     spec:
       restartPolicy: Never
       containers:
-      - name: {{ include "iglu.hooks.name" . }}-db-dev-user-setup
+      - name: {{ include "iglu.hooks.name" . }}-dev-db-user-setup
         image: postgres:15
         imagePullPolicy: Always
         command: ["/bin/bash", "-c"]

--- a/charts/snowplow-iglu-server/values-azure.yaml.tmpl
+++ b/charts/snowplow-iglu-server/values-azure.yaml.tmpl
@@ -32,3 +32,9 @@ service:
   ingress: 
     ingress-01:
       hostname: "iglu-server.example.com"
+  
+  azure: 
+    dev_db: "<dev_db>"
+    secrets:
+      admin_username: "<admin_username>"
+      dev_username "<dev_username>"

--- a/charts/snowplow-iglu-server/values.yaml
+++ b/charts/snowplow-iglu-server/values.yaml
@@ -86,12 +86,12 @@ service:
     # -- EC2 TargetGroup ARN to bind the service onto
     targetGroupARN: ""
 
-  azure: 
+  azure:
     # -- Whether we deploy for dev db
     dev_db: ""
     secrets:
       admin_username: ""
-      dev_username: ""    
+      dev_username: ""
 
   gcp:
     # -- Name of the Network Endpoint Group to bind onto

--- a/charts/snowplow-iglu-server/values.yaml
+++ b/charts/snowplow-iglu-server/values.yaml
@@ -88,7 +88,7 @@ service:
 
   azure:
     # -- Whether we deploy for dev db
-    dev_db: ""
+    dev_db: false
     secrets:
       admin_username: ""
       dev_username: ""

--- a/charts/snowplow-iglu-server/values.yaml
+++ b/charts/snowplow-iglu-server/values.yaml
@@ -86,6 +86,13 @@ service:
     # -- EC2 TargetGroup ARN to bind the service onto
     targetGroupARN: ""
 
+  azure: 
+    # -- Whether we deploy for dev db
+    dev_db: ""
+    secrets:
+      admin_username: ""
+      dev_username: ""    
+
   gcp:
     # -- Name of the Network Endpoint Group to bind onto
     networkEndpointGroupName: ""

--- a/charts/snowplow-iglu-server/values.yaml
+++ b/charts/snowplow-iglu-server/values.yaml
@@ -70,7 +70,7 @@ service:
       # -- Postgres database port
       port: 5432
       # -- Postgres database name
-      dbname: ""
+      dbname: false
       secrets:
         username: ""
         password: ""

--- a/charts/snowplow-iglu-server/values.yaml
+++ b/charts/snowplow-iglu-server/values.yaml
@@ -70,7 +70,7 @@ service:
       # -- Postgres database port
       port: 5432
       # -- Postgres database name
-      dbname: false
+      dbname: ""
       secrets:
         username: ""
         password: ""


### PR DESCRIPTION
This PR updates helm hook job for iglu so that it includes a job for setting the dev db postgres user in Azure. Up until now the postrgres user for dev db was created using a local-exec, we are moving this to a helm hook job.

See #196 
