### PR TITLE
charts/aws-otel-collector add cluster label to scrape config (closes #192)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.73 (2024-08-29)
+---------------------------
+charts/aws-otel-collector add cluster_name label to prometheus scrap config (closes #192)
+
 Version 0.1.72 (2024-08-27)
 ---------------------------
 charts/service-deployment add support for tolerations and topologySpreadConstraints (closes #165, closes #189)

--- a/charts/aws-otel-collector/Chart.yaml
+++ b/charts/aws-otel-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-otel-collector
 description: A Helm chart to deploy aws-otel-collector project
-version: 0.3.0
+version: 0.4.0
 appVersion: "v0.33.1"
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts

--- a/charts/aws-otel-collector/README.md
+++ b/charts/aws-otel-collector/README.md
@@ -39,6 +39,7 @@ helm delete aws-otel-collector --namespace kube-system
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| clusterName | string | `""` | Sets cluster name for log groups and kube label for prometheus metric dimensions |
 | nameOverride | string | `""` | Overrides the name given to the deployment (default: .Release.Name) |
 | fullnameOverride | string | `""` | Overrides the full-name given to the deployment resources (default: .Release.Name) |
 | image.repository | string | `"public.ecr.aws/aws-observability/aws-otel-collector"` | Image to use for deploying |

--- a/charts/aws-otel-collector/templates/configmap.yaml
+++ b/charts/aws-otel-collector/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
     exporters:
       awsemf:
         namespace: ContainerInsights
-        log_group_name: '/aws/containerinsights/{ClusterName}/performance'
+        log_group_name: '/aws/containerinsights/{{ .Values.clusterName }}/performance'
         log_stream_name: '{NodeName}'
         log_retention: {{ .Values.performance_log_retention_in_days }}
         resource_to_telemetry_conversion:
@@ -77,8 +77,10 @@ data:
               metrics_path: /metrics
               scheme: http
               static_configs:
-              - targets:
-                - prometheus-kube-state-metrics.monitoring.svc.cluster.local:8080
+                - targets:
+                  - prometheus-kube-state-metrics.monitoring.svc.cluster.local:8080
+                  labels:
+                    cluster_name: {{ .Values.clusterName }}
 
     processors:
       batch/metrics:
@@ -99,7 +101,7 @@ data:
     exporters:
       awsemf:
         namespace: ContainerInsights
-        log_group_name: '/aws/containerinsights/{ClusterName}/performance'
+        log_group_name: '/aws/containerinsights/{{ .Values.clusterName }}/performance'
         log_stream_name: '{NodeName}'
         log_retention: {{ .Values.performance_log_retention_in_days }}
         resource_to_telemetry_conversion:
@@ -124,7 +126,7 @@ data:
 
       awsemf/prometheus:
         namespace: ContainerInsights/Prometheus
-        log_group_name: "/aws/containerinsights/{TaskId}/prometheus"
+        log_group_name: '/aws/containerinsights/{{ .Values.clusterName }}/{TaskId}/prometheus'
         log_stream_name: "{TaskId}"
         log_retention: {{ .Values.prometheus_log_retention_in_days }}
         resource_to_telemetry_conversion:
@@ -135,7 +137,7 @@ data:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         metric_declarations:
-        - dimensions: [[ namespace, deployment ]]
+        - dimensions: [[ namespace, deployment, cluster_name ]]
           metric_name_selectors:
             - "^kube_deployment_status_replicas_ready$"
           label_matchers:

--- a/charts/aws-otel-collector/values.yaml
+++ b/charts/aws-otel-collector/values.yaml
@@ -2,6 +2,8 @@
 nameOverride: ""
 # -- Overrides the full-name given to the deployment resources (default: .Release.Name)
 fullnameOverride: ""
+# -- Sets cluster name for scraping metric and log groups
+clusterName: ""
 
 image:
   # -- Image to use for deploying


### PR DESCRIPTION
This PR updates aws-otel-collector helm chart to provide `clusterName` in values.yaml to set log group naming, and also add as a label to prometheus receiver scrape config. This allows metric_declarations to also set `cluster_name` to be able to differentiate kube state metrics by `cluster name`, along with `namespace` and `deployment` 