### PR TITLE
Update resource allocation for aws-otel-collector

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.74 (2024-08-30)
+---------------------------
+charts/aws-otel-collector: change default resource allocation (#198)
+
 Version 0.1.73 (2024-08-29)
 ---------------------------
 charts/aws-otel-collector add cluster_name label to prometheus scrap config (closes #192)

--- a/charts/aws-otel-collector/Chart.yaml
+++ b/charts/aws-otel-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-otel-collector
 description: A Helm chart to deploy aws-otel-collector project
-version: 0.4.0
+version: 0.4.1
 appVersion: "v0.33.1"
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts

--- a/charts/aws-otel-collector/values.yaml
+++ b/charts/aws-otel-collector/values.yaml
@@ -13,11 +13,10 @@ image:
 
 resources:
   limits:
-    cpu: 200m
     memory: 200Mi
   requests:
-    cpu: 200m
-    memory: 200Mi
+    cpu: 20m
+    memory: 100Mi
 
 serviceAccount:
   # -- Whether to create a service account or not


### PR DESCRIPTION
This brings this daemonset more into line with other deployments and means that we aren't chewing up 10% of the available box CPU for something that barely scratches 1%.