### PR TITLE
snowplow-iglu-server: toleration and topologySpreadConstraints (closes #194)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.76 (2024-10-23)
+---------------------------
+charts/snowplow-iglu-server: add support for tolerations and topologySpreadConstraints (closes #194)
+
 Version 0.1.75 (2024-08-30)
 ---------------------------
 charts/snowplow-iglu-server: Create Helm Hook Job for DB users and permissions (closes #196)

--- a/charts/snowplow-iglu-server/Chart.yaml
+++ b/charts/snowplow-iglu-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: snowplow-iglu-server
 description: A Helm Chart to deploy the Snowplow Iglu Server project
-version: 0.8.0
+version: 0.9.0
 appVersion: "0.12.0"
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts

--- a/charts/snowplow-iglu-server/README.md
+++ b/charts/snowplow-iglu-server/README.md
@@ -204,3 +204,5 @@ You will need to fill these targeted fields:
 | service.resources.requests.memory | string | `"512Mi"` |  |
 | service.targetCPUUtilizationPercentage | int | `75` |  |
 | service.terminationGracePeriodSeconds | int | `630` |  |
+| service.tolerations | list |`[]` | Tolerations labels for pod assignment with matching taints |
+| service.topologySpreadConstraints | object | `{}` | Topology Spread Constraints for pod assignment |

--- a/charts/snowplow-iglu-server/templates/iglu-deployment.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-deployment.yaml
@@ -30,6 +30,15 @@ spec:
       - name: {{ .Values.dockerconfigjson.name }}
       {{- end }}
 
+      {{- with .Values.service.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.service.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
       volumes:
       {{- if ne .Values.service.config.hoconBase64 "" }}
       - configMap:

--- a/charts/snowplow-iglu-server/values.yaml
+++ b/charts/snowplow-iglu-server/values.yaml
@@ -42,6 +42,16 @@ service:
     failureThreshold: 3
     successThreshold: 2
 
+  # -- Allow the scheduler to schedule pods with matching taints
+  #
+  # more details here: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  tolerations: []
+
+  # -- topologySpreadConstraints control how Pods are  spread across your cluster among failure-domains such as regions, zones, nodes, and other user-defined topology domains.
+  #
+  # more details here: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  topologySpreadConstraints: {}
+
   resources:
     limits:
       cpu: 746m


### PR DESCRIPTION
Add support for tolerations and topologySpreadConstraints

Below is output from `helm template snowplow-iglu-server` with and without tolerations and topology spread constraints being set

```
➜ helm template snowplow-iglu-server
<truncated>
---
# Source: snowplow-iglu-server/templates/iglu-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-app
  labels:
    helm.sh/chart: snowplow-iglu-server-0.9.0
    app.kubernetes.io/version: "0.9.0"
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    matchLabels:
      app: release-name-app
  template:
    metadata:
      labels:
        app: release-name-app
        helm.sh/chart: snowplow-iglu-server-0.9.0
        app.kubernetes.io/version: "0.9.0"
        app.kubernetes.io/managed-by: Helm
      annotations:
        checksum/config: "f786bb986a29772d4b6bd8d30637545bb4a96d1445322376cdf913913563bf8a"
    spec:
      automountServiceAccountToken: true
      terminationGracePeriodSeconds: 630

      volumes:

      containers:
      - name: release-name-app
        image: snowplow/iglu-server:0.12.0-distroless
        imagePullPolicy: IfNotPresent

        args:
        - "--config"
        -  "/dev/null" 

        ports:
        - containerPort: 8080
          protocol: TCP

        env:
        - name: "ACCEPT_LIMITED_USE_LICENSE"
          value: "no"
        - name : "CONFIG_FORCE_iglu_repoServer_port"
          value: "8080"
        - name : "CONFIG_FORCE_iglu_repoServer_maxConnections"
          value: "16384"
        - name : "CONFIG_FORCE_iglu_repoServer_idleTimeout"
          value: "65 seconds"
        - name : "CONFIG_FORCE_iglu_repoServer_hsts_enable"
          value: "true"
        - name : "CONFIG_FORCE_iglu_database_type"
          value: "dummy"
        - name : "CONFIG_FORCE_iglu_database_host"
          value: ""
        - name : "CONFIG_FORCE_iglu_database_port"
          value: "5432"
        - name : "CONFIG_FORCE_iglu_database_dbname"
          value: ""
        - name : "CONFIG_FORCE_iglu_patchesAllowed"
          value: "false"
        - name : "JDK_JAVA_OPTIONS"
          value: "-Dconfig.override_with_env_vars=true "

        envFrom:
        - secretRef:
            name: release-name-secret

        livenessProbe:
          httpGet:
            path: /api/meta/health
            port: 8080
            scheme: HTTP
          initialDelaySeconds: 30
          periodSeconds: 5
          timeoutSeconds: 5
          failureThreshold: 3

        readinessProbe:
          httpGet:
            path: /api/meta/health
            port: 8080
            scheme: HTTP
          initialDelaySeconds: 5
          periodSeconds: 5
          timeoutSeconds: 5
          failureThreshold: 3
          successThreshold: 2 

        resources:
          limits:
            cpu: 746m
            memory: 900Mi
          requests:
            cpu: 400m
            memory: 512Mi

        volumeMounts:
---
```

With tolerations and topologySpreadConstraint being set 

```
➜ helm template snowplow-iglu-server \                                                        
  --set "service.tolerations[0].key=key1" \
  --set "service.tolerations[0].operator=Exists" \
  --set "service.tolerations[0].effect=NoSchedule" \
  --set "service.topologySpreadConstraints[0].maxSkew=1" \
  --set "service.topologySpreadConstraints[0].topologyKey=topology.kubernetes.io/zone" \
  --set "service.topologySpreadConstraints[0].whenUnsatisfiable=DoNotSchedule"
  
  
  
  # Source: snowplow-iglu-server/templates/iglu-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-app
  labels:
    helm.sh/chart: snowplow-iglu-server-0.9.0
    app.kubernetes.io/version: "0.9.0"
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    matchLabels:
      app: release-name-app
  template:
    metadata:
      labels:
        app: release-name-app
        helm.sh/chart: snowplow-iglu-server-0.9.0
        app.kubernetes.io/version: "0.9.0"
        app.kubernetes.io/managed-by: Helm
      annotations:
        checksum/config: "6d66497e23af0d7ae4cc674ffea3cf2bb9c5335d37f058ba60a8e3f9d53847d4"
    spec:
      automountServiceAccountToken: true
      terminationGracePeriodSeconds: 630
      tolerations:
        - effect: NoSchedule
          key: key1
          operator: Exists
      topologySpreadConstraints:
        - maxSkew: 1
          topologyKey: topology.kubernetes.io/zone
          whenUnsatisfiable: DoNotSchedule

      volumes:

      containers:
      - name: release-name-app
        image: snowplow/iglu-server:0.12.0-distroless
        imagePullPolicy: IfNotPresent

        args:
        - "--config"
        -  "/dev/null" 

        ports:
        - containerPort: 8080
          protocol: TCP

        env:
        - name: "ACCEPT_LIMITED_USE_LICENSE"
          value: "no"
        - name : "CONFIG_FORCE_iglu_repoServer_port"
          value: "8080"
        - name : "CONFIG_FORCE_iglu_repoServer_maxConnections"
          value: "16384"
        - name : "CONFIG_FORCE_iglu_repoServer_idleTimeout"
          value: "65 seconds"
        - name : "CONFIG_FORCE_iglu_repoServer_hsts_enable"
          value: "true"
        - name : "CONFIG_FORCE_iglu_database_type"
          value: "dummy"
        - name : "CONFIG_FORCE_iglu_database_host"
          value: ""
        - name : "CONFIG_FORCE_iglu_database_port"
          value: "5432"
        - name : "CONFIG_FORCE_iglu_database_dbname"
          value: ""
        - name : "CONFIG_FORCE_iglu_patchesAllowed"
          value: "false"
        - name : "JDK_JAVA_OPTIONS"
          value: "-Dconfig.override_with_env_vars=true "

        envFrom:
        - secretRef:
            name: release-name-secret

        livenessProbe:
          httpGet:
            path: /api/meta/health
            port: 8080
            scheme: HTTP
          initialDelaySeconds: 30
          periodSeconds: 5
          timeoutSeconds: 5
          failureThreshold: 3

        readinessProbe:
          httpGet:
            path: /api/meta/health
            port: 8080
            scheme: HTTP
          initialDelaySeconds: 5
          periodSeconds: 5
          timeoutSeconds: 5
          failureThreshold: 3
          successThreshold: 2 

        resources:
          limits:
            cpu: 746m
            memory: 900Mi
          requests:
            cpu: 400m
            memory: 512Mi

        volumeMounts:
  <truncated>
```