### PR TITLE
Update service-deployment HPA metrics (closes #202)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.77 (2024-10-25)
+---------------------------
+charts/service-deployment: update hpa to supply metrics object instead of fixed CPU utilization threshold (closes #202)
+
 Version 0.1.76 (2024-10-23)
 ---------------------------
 charts/snowplow-iglu-server: add support for tolerations and topologySpreadConstraints (closes #194)

--- a/charts/service-deployment/Chart.yaml
+++ b/charts/service-deployment/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: service-deployment
 description: A Helm Chart to setup a generic deployment with optional service/hpa bindings
-version: 0.20.0
+version: 0.21.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/service-deployment/README.md
+++ b/charts/service-deployment/README.md
@@ -71,7 +71,7 @@ helm delete service-deployment
 | fullnameOverride | string | `""` | Overrides the full-name given to the deployment resources (default: .Release.Name) |
 | global.cloud | string | `""` | Cloud specific bindings (options: aws, gcp , azure) |
 | global.labels | object | `{}` | Global labels deployed to all resources deployed by the chart |
-| hpa.averageCPUUtilization | int | `75` | Average CPU utilization before auto-scaling starts |
+| hpa.metrics | object | `[{"type":"Resource","resource":{"name":"cpu","target":{"type":"Utilization","averageUtilization":75}}}]` | Metrics for HPA configuration |
 | hpa.behavior | object | `{}` |  |
 | hpa.deploy | bool | `true` | Whether to deploy HPA rules |
 | hpa.maxReplicas | int | `20` | Maximum number of pods to deploy |

--- a/charts/service-deployment/templates/hpa.yaml
+++ b/charts/service-deployment/templates/hpa.yaml
@@ -12,10 +12,8 @@ spec:
     name: {{ include "app.fullname" . }}
   minReplicas: {{ .Values.hpa.minReplicas }}
   maxReplicas: {{ .Values.hpa.maxReplicas }}
-  {{- if .Values.hpa.metrics }}
   metrics:
     {{- toYaml .Values.hpa.metrics | nindent 4 }}
-  {{- end }}
   behavior:
     {{- toYaml .Values.hpa.behavior | nindent 4 }}
 {{- end }}

--- a/charts/service-deployment/templates/hpa.yaml
+++ b/charts/service-deployment/templates/hpa.yaml
@@ -12,13 +12,10 @@ spec:
     name: {{ include "app.fullname" . }}
   minReplicas: {{ .Values.hpa.minReplicas }}
   maxReplicas: {{ .Values.hpa.maxReplicas }}
+  {{- if .Values.hpa.metrics }}
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.hpa.averageCPUUtilization }}
+    {{- toYaml .Values.hpa.metrics | nindent 4 }}
+  {{- end }}
   behavior:
     {{- toYaml .Values.hpa.behavior | nindent 4 }}
 {{- end }}

--- a/charts/service-deployment/values.yaml
+++ b/charts/service-deployment/values.yaml
@@ -92,8 +92,14 @@ hpa:
   minReplicas: 1
   # -- Maximum number of pods to deploy
   maxReplicas: 20
-  # -- Average CPU utilization before auto-scaling starts
-  averageCPUUtilization: 75
+  # -- Default average CPU utilization before auto-scaling starts
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 75
   behavior: {}
 
 service:


### PR DESCRIPTION
This PR updates service-deployment helm chart to not be fixed to just CPU based autoscaling. 

- Updated hpa template to allow passing in metrics instead of just average target utilization for CPU  




```
helm template service-deployment \
  --set 'hpa.metrics[0].type=Resource' \
  --set 'hpa.metrics[0].resource.name=memory' \
  --set 'hpa.metrics[0].resource.target.type=Utilization' \
  --set 'hpa.metrics[0].resource.target.averageUtilization=75' \
  --set 'hpa.metrics[1].type=Resource' \
  --set 'hpa.metrics[1].resource.name=cpu' \
  --set 'hpa.metrics[1].resource.target.type=Utilization' \
  --set 'hpa.metrics[1].resource.target.averageUtilization=75'
  
 
---
# Source: service-deployment/templates/hpa.yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: release-name
  labels:
    helm.sh/chart: service-deployment-0.21.0
    app.kubernetes.io/version: "0.21.0"
    app.kubernetes.io/managed-by: Helm
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: release-name
  minReplicas: 1
  maxReplicas: 20
  metrics:
    - resource:
        name: memory
        target:
          averageUtilization: 75
          type: Utilization
      type: Resource
    - resource:
        name: cpu
        target:
          averageUtilization: 75
          type: Utilization
      type: Resource
  behavior:
    {}
```