### PR TITLE
Create helm hook job for dev database creation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.78 (2024-10-28)
+---------------------------
+charts/snowplow-iglu-server: Adds helm hook job to create dev database (closes #205)
+
 Version 0.1.77 (2024-10-25)
 ---------------------------
 charts/service-deployment: update hpa to supply metrics object instead of fixed CPU utilization threshold (closes #202)

--- a/charts/snowplow-iglu-server/Chart.yaml
+++ b/charts/snowplow-iglu-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: snowplow-iglu-server
 description: A Helm Chart to deploy the Snowplow Iglu Server project
-version: 0.9.0
+version: 0.10.0
 appVersion: "0.12.0"
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts

--- a/charts/snowplow-iglu-server/README.md
+++ b/charts/snowplow-iglu-server/README.md
@@ -122,6 +122,8 @@ When `dev_db` is `true` the hook job `-dev-db-user-setup` will be initiated
 
 ### AWS (EKS) settings
 
+When `dev_db` is `true` the hook job `-create-dev-db` will be initiated
+
 #### TargetGroup binding
 
 To manage the load balancer externally to the kubernetes cluster you can bind the deployment to an existing TargetGroup ARN.  Its important that the TargetGroup exist ahead of time and that you use the same port as you have used in your `values.yaml`. 
@@ -151,6 +153,8 @@ You will need to fill these targeted fields:
 | global.labels | object | `{}` | Global labels deployed to all resources deployed by the chart |
 | service.annotations | object | `{}` | Map of annotations to add to the service |
 | service.aws.targetGroupARN | string | `""` | EC2 TargetGroup ARN to bind the service onto |
+| service.aws.dev_db | bool | `false` | Whether we deploy for dev db in AWS |
+| service.aws.secrets.admin_username | string | `""` | The admin username that will be used for the psql command |
 | service.config.database.dbname | string | `""` | Postgres database name |
 | service.config.database.host | string | `""` | Postgres database host |
 | service.config.database.port | int | `5432` | Postgres database port |

--- a/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-hooks.yaml
@@ -101,7 +101,58 @@ spec:
         - name: "CONFIG_FORCE_iglu_database_dbname"
           value: "{{ .Values.service.config.database.dbname }}"
         - name: "CONFIG_FORCE_iglu_database_port"
-          value: "{{ .Values.service.gcp.proxy.port }}"
+          value: "{{ .Values.service.config.database.port }}"
+        envFrom:
+        - secretRef:
+            name: {{ include "iglu.app.secret.name" . }}
+{{- end }}
+
+{{- if .Values.service.aws.dev_db }}
+
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "iglu.hooks.name" . }}-create-dev-db
+  labels:
+    {{- include "snowplow.labels" $ | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-weight": "1"
+spec:
+  template:
+    metadata:
+      name: {{ include "iglu.hooks.name" . }}-create-dev-db
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: {{ include "iglu.hooks.name" . }}-create-dev-db
+        image: postgres:15-alpine
+        imagePullPolicy: Always
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            export PGPASSWORD="${CONFIG_FORCE_iglu_database_admin_password}"
+            psql -h "${CONFIG_FORCE_iglu_database_host}" \
+                 -d "${CONFIG_FORCE_iglu_database_prod_dbname}" \
+                 -U "${CONFIG_FORCE_iglu_database_admin_username}" \
+                 -p "${CONFIG_FORCE_iglu_database_port}" \
+                 -c "CREATE DATABASE ${CONFIG_FORCE_iglu_database_dbname};" && echo "OK"
+        env:
+        - name: "CONFIG_FORCE_iglu_database_admin_password"
+          value: "{{ .Values.service.aws.secrets.admin_password }}"
+        - name: "CONFIG_FORCE_iglu_database_admin_username"
+          value: "{{ .Values.service.aws.secrets.admin_username }}"
+        - name: "CONFIG_FORCE_iglu_database_prod_dbname"
+          value: "{{ .Values.service.aws.prod_dbname }}"
+        - name: "CONFIG_FORCE_iglu_database_host"
+          value: "{{ .Values.service.config.database.host }}"
+        - name: "CONFIG_FORCE_iglu_database_dbname"
+          value: "{{ .Values.service.config.database.dbname }}"
+        - name: "CONFIG_FORCE_iglu_database_port"
+          value: "{{ .Values.service.config.database.port }}"
         envFrom:
         - secretRef:
             name: {{ include "iglu.app.secret.name" . }}

--- a/charts/snowplow-iglu-server/values-aws.yaml.tmpl
+++ b/charts/snowplow-iglu-server/values-aws.yaml.tmpl
@@ -32,3 +32,8 @@ service:
 
   aws:
     targetGroupARN: "<target-group-arn>"
+    dev_db: "<dev_db>"
+    prod_dbname: "<prod_dbname>"
+    secrets:
+      admin_username: "<admin_username>"
+      dev_username "<dev_username>"

--- a/charts/snowplow-iglu-server/values-aws.yaml.tmpl
+++ b/charts/snowplow-iglu-server/values-aws.yaml.tmpl
@@ -36,4 +36,3 @@ service:
     prod_dbname: "<prod_dbname>"
     secrets:
       admin_username: "<admin_username>"
-      dev_username "<dev_username>"

--- a/charts/snowplow-iglu-server/values.yaml
+++ b/charts/snowplow-iglu-server/values.yaml
@@ -100,7 +100,6 @@ service:
     prod_dbname: ""
     secrets:
       admin_username: ""
-      dev_username: ""
 
   azure:
     # -- Whether we deploy for dev db

--- a/charts/snowplow-iglu-server/values.yaml
+++ b/charts/snowplow-iglu-server/values.yaml
@@ -85,6 +85,12 @@ service:
   aws:
     # -- EC2 TargetGroup ARN to bind the service onto
     targetGroupARN: ""
+    # -- Whether we deploy for dev db
+    dev_db: false
+    prod_dbname: ""
+    secrets:
+      admin_username: ""
+      dev_username: ""
 
   azure:
     # -- Whether we deploy for dev db


### PR DESCRIPTION
This PR adds a helm hook job for iglu to create the devdb database when deploying in AWS

See https://github.com/snowplow-devops/helm-charts/issues/205