### PR TITLE
charts/cert-manager-issuer add external issuer support (closes #222)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.84 (2025-03-28)
+---------------------------
+charts/cert-manager-issuer: add external issuer support (#222)
+
 Version 0.1.83 (2025-02-21)
 ---------------------------
 charts/service-deployment: enables setting single replica without HPA deployment (#218)

--- a/charts/cert-manager-issuer/Chart.yaml
+++ b/charts/cert-manager-issuer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cert-manager-issuer
 description: A helm chart that creates an Issuer or ClusterIssuer for cert-manager
-version: 0.1.0
+version: 0.2.0
 type: application
 home: https://github.com/snowplow-devops/helm-charts
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png

--- a/charts/cert-manager-issuer/README.md
+++ b/charts/cert-manager-issuer/README.md
@@ -23,7 +23,7 @@ A helm chart that creates an Issuer or ClusterIssuer for cert-manager
 | acme.accountPrivateKeyData | string | `""` | A private key to use for registration (if not provided, one will be generated) |
 | acme.email | string | `"firstname.lastname@example.com"` | The email address to use for registration |
 | acme.enabled | bool | `true` | Whether to enable the ACME protocol |
-| acme.environment | string | `"letsencrypt-staging"` | The ACME server to use (options: letsencrypt, letsencrypt-staging) |
+| acme.environment | string | `"letsencrypt-staging"` | The ACME server to use (options: letsencrypt, letsencrypt-staging, external-zerossl) |
 | acme.httpSolverIngressClass | string | `"traefik"` | The name of the ingress class to setup the HTTP-01 challenge solver on |
 | acme.solver | string | `"http01"` | The type of challenge to use (options: http01, dns01) |
 | global.cloud | string | `""` | Cloud specific bindings (options: aws, gcp, azure. Only used for dns01 type) |

--- a/charts/cert-manager-issuer/templates/_helpers.tpl
+++ b/charts/cert-manager-issuer/templates/_helpers.tpl
@@ -23,8 +23,8 @@ If release name contains chart name it will be used as a full name.
 {{ include "app.fullname" . }}-secret
 {{- end -}}
 {{- define "validate-environment" -}}
-{{- if not (or (eq .Values.acme.environment "letsencrypt") (eq .Values.acme.environment "letsencrypt-staging")) -}}
-{{- printf "Error: invalid acme.environment (%s). Allowed values: letsencrypt, letsencrypt-staging." .Values.acme.environment | fail -}}
+{{- if not (or (eq .Values.acme.environment "letsencrypt") (eq .Values.acme.environment "letsencrypt-staging") (eq .Values.acme.environment "external-zerossl")) -}}
+{{- printf "Error: invalid acme.environment (%s). Allowed values: letsencrypt, letsencrypt-staging, external-zerossl." .Values.acme.environment | fail -}}
 {{- end -}}
 {{- end -}}
 {{- define "validate-type" -}}
@@ -37,5 +37,7 @@ If release name contains chart name it will be used as a full name.
 {{- print "https://acme-v02.api.letsencrypt.org/directory" | trim | replace " " "" -}}
 {{- else if eq .Values.acme.environment "letsencrypt-staging" -}}
 {{- print "https://acme-staging-v02.api.letsencrypt.org/directory" | trim | replace " " "" -}}
+{{- else if eq .Values.acme.environment "external-zerossl" -}}
+{{- print "https://acme.zerossl.com/v2/DV90" | trim | replace " " "" -}}
 {{- end -}}
 {{- end -}}

--- a/charts/cert-manager-issuer/templates/issuer.yaml
+++ b/charts/cert-manager-issuer/templates/issuer.yaml
@@ -5,7 +5,16 @@ metadata:
 spec:
   {{- if .Values.acme.enabled}}
   acme:
+    {{- if eq (include "app.fullname" .) "letsencrypt" }}
     email: {{ .Values.acme.email }}
+    {{- else if contains "external" (include "app.fullname" .) }}
+    externalAccountBinding:
+      keyID: {{ .Values.acme.EABKeyId }}
+      keySecretRef:
+        name: {{ include "app.fullname" . }}-eabsecret
+        key: secret
+      keyAlgorithm: HS256
+    {{- end}}
     {{- if .Values.acme.accountPrivateKeyData}}
     disableAccountKeyGeneration: true
     {{- end }}

--- a/charts/cert-manager-issuer/templates/secrets.yaml
+++ b/charts/cert-manager-issuer/templates/secrets.yaml
@@ -8,3 +8,13 @@ type: Opaque
 data:
     tls.key: {{ .Values.acme.accountPrivateKeyData | b64enc | quote }}
 {{ end }}
+
+---
+{{ if contains "external" (include "app.fullname" .) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "app.fullname" . }}-eabsecret
+data:
+  secret: {{ .Values.acme.EABHmacKey | b64enc | quote }}
+{{ end }}

--- a/charts/cert-manager-issuer/values.yaml
+++ b/charts/cert-manager-issuer/values.yaml
@@ -8,12 +8,16 @@ issuerType: "cluster"
 acme:
   # -- Whether to enable the ACME protocol
   enabled: true
-  # -- The ACME server to use (options: letsencrypt, letsencrypt-staging)
+  # -- The ACME server to use (options: letsencrypt, letsencrypt-staging, external-zerossl)
   environment: letsencrypt-staging
   # -- The email address to use for registration
   email: "firstname.lastname@example.com"
   # -- A private key to use for registration (if not provided, one will be generated)
   accountPrivateKeyData: ""
+  # -- External Account Binding (EAB) Key ID, required for ACME registration with providers like ZeroSSL and Cloudflare.
+  EABKeyId: ""
+  # -- External Account Binding (EAB) HMAC Key, used to cryptographically sign requests during ACME registration.
+  EABHmacKey: ""
   # -- The type of challenge to use (options: http01, dns01)
   solver: "http01"
   # -- The name of the ingress class to setup the HTTP-01 challenge solver on

--- a/charts/cert-manager-issuer/values.yaml
+++ b/charts/cert-manager-issuer/values.yaml
@@ -14,7 +14,7 @@ acme:
   email: "firstname.lastname@example.com"
   # -- A private key to use for registration (if not provided, one will be generated)
   accountPrivateKeyData: ""
-  # -- External Account Binding (EAB) Key ID, required for ACME registration with providers like ZeroSSL and Cloudflare.
+  # -- External Account Binding (EAB) Key ID, required for ACME registration with providers like ZeroSSL.
   EABKeyId: ""
   # -- External Account Binding (EAB) HMAC Key, used to cryptographically sign requests during ACME registration.
   EABHmacKey: ""


### PR DESCRIPTION
This PR adds external issuer support to charts/cert-manager-issuer. Added initial support for ZeroSSL. 