### PR TITLE
charts/service-deployment add support for mounting separate deployment configMaps (closes #228)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.85 (2025-04-14)
+---------------------------
+charts/service-deployment: add support for mounting separate deployment configMaps (#228)
+
 Version 0.1.84 (2025-03-28)
 ---------------------------
 charts/cert-manager-issuer: add external issuer support (#222)

--- a/charts/service-deployment/Chart.yaml
+++ b/charts/service-deployment/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: service-deployment
 description: A Helm Chart to setup a generic deployment with optional service/hpa bindings
-version: 0.23.0
+version: 0.24.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/service-deployment/README.md
+++ b/charts/service-deployment/README.md
@@ -55,6 +55,7 @@ helm delete service-deployment
 | config.env | string | `nil` | Map of environment variables to use within the job |
 | config.secrets | object | `{}` | Map of secrets that will be exposed as environment variables within the job |
 | config.secretsB64 | object | `{}` | Map of base64-encoded secrets that will be exposed as environment variables within the job |
+| config.sharedNamespaceConfigMaps | list | `[]` | List of config maps from same namespace to reference and mount in the deployment |
 | configMaps | list | `[]` | List of config maps to mount to the deployment |
 | deployment.kind | string | `"Deployment"` | Can be either a "Deployment" or "StatefulSet" |
 | deployment.podLabels | object | `{}` | Map of labels that will be added to each pod in the deployment |

--- a/charts/service-deployment/templates/deployment.yaml
+++ b/charts/service-deployment/templates/deployment.yaml
@@ -60,6 +60,12 @@ spec:
           optional: false
         name: {{ $v.name }}
       {{- end }}
+      {{- range $v := .Values.config.sharedNamespaceConfigMaps }}
+      - configMap:
+          name: {{ $v.name }}
+          optional: false
+        name: {{ $v.name }}
+      {{- end }}
       {{- if and (.Values.persistentVolume.enabled) (eq .Values.deployment.kind "Deployment") }}
       - name: storage-volume
         persistentVolumeClaim:
@@ -169,6 +175,12 @@ spec:
           mountPropagation: None
           {{- end }}
           name: {{ $v.name }}
+        {{- end }}
+        {{- range $v := .Values.config.sharedNamespaceConfigMaps }}
+        - name: "{{ $v.name }}"
+          mountPath: "{{ $v.mountPath }}"
+          mountPropagation: {{ default "None" $v.mountPropagation }}
+          readOnly: {{ default true $v.readOnly }}
         {{- end }}
         {{- if and (.Values.persistentVolume.enabled) (eq .Values.deployment.kind "Deployment") }}
         - name: storage-volume

--- a/charts/service-deployment/values.yaml
+++ b/charts/service-deployment/values.yaml
@@ -34,6 +34,16 @@ config:
   secretsB64: {}
   #  username: "cGFzc3dvcmQK"
 
+  # -- List of configMaps from other deployments within the
+  #    same namespace - to reference and mount in the deployment
+  sharedNamespaceConfigMaps: []
+  #  - name: "10c8b-config-fs-dev1"
+  #    mountPath: "/etc/config" # Must match the path of referenced volume
+  #    mountPropagation: None # If unset will default to 'None'
+  #    readOnly: true #  If unset will default to 'true'
+  #  - name: "another-shared-configmap"
+  #    mountPath: "/app/config" # Must match the path of referenced volume
+
 # -- List of config maps to mount to the deployment
 configMaps: []
 #  - name: "volume-1"


### PR DESCRIPTION
This PR adds in the ability to pass in configMap references that already exist within the same namespace and allow deployment container to mount

An example is Service A deploys a configMap that Service B also needs to reference. Currently the only approach is to create a copy of the configMap specific to Service Bs deployment. This requires updating two helm deployments for Service B to pick up the same details
