### PR TITLE
Cron job 0.11.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Version 0.1.89 (2025-05-28)
+---------------------------
+charts/cron-job: Add ability to specify resources (#236)
+charts/cron-job: Add ability to specify fine-grained custom roles (#237)
+
 Version 0.1.88 (2025-05-21)
 ---------------------------
 charts/cron-job: attach custom role to service account (#234)

--- a/charts/cron-job/Chart.yaml
+++ b/charts/cron-job/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cron-job
 description: A Helm Chart to deploy an arbitrary container as a cron job.
-version: 0.10.0
+version: 0.11.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/cron-job/README.md
+++ b/charts/cron-job/README.md
@@ -67,6 +67,4 @@ helm delete cron-job
 | cloudserviceaccount.gcp.serviceAccount | string | `""` | Service Account email to bind to the k8s service account |
 | cloudserviceaccount.azure.managedIdentityId | string | `""` | Workload managed identity id to bind to the k8s service account |
 | customRole.deploy | bool | `false` | Whether to deploy the custom role and bind it to the cloudserviceaccount |
-| customRole.apiGroups | list | `[]` | APIGroups is the name of the APIGroup that contains the resources |
-| customRole.resources | list | `[]` | Resources is a list of resources this rule applies to |
-| customRole.verbs | list | `[]` | Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule |
+| customRole.definition | list | `[]` | Array of role definitions to setup for the custom role |

--- a/charts/cron-job/README.md
+++ b/charts/cron-job/README.md
@@ -55,6 +55,7 @@ helm delete cron-job
 | config.env | object | `{}` | Map of environment variables to use within the job |
 | config.secrets | object | `{}` | Map of secrets that will be exposed as environment variables within the job |
 | configMaps | list | `[]` | List of config maps to mount to the deployment |
+| resources | object | `{}` | Map of resource constraints for the deployment |
 | dockerconfigjson.name | string | `"snowplow-cron-job-dockerhub"` | Name of the secret to use for the private repository |
 | dockerconfigjson.username | string | `""` | Username for the private repository |
 | dockerconfigjson.password | string | `""` | Password for the private repository |

--- a/charts/cron-job/templates/deployment.yaml
+++ b/charts/cron-job/templates/deployment.yaml
@@ -79,6 +79,9 @@ spec:
                 name: {{ include "app.secret.fullname" . }}
             {{- end }}
 
+            resources:
+              {{- toYaml .Values.resources | nindent 14 }}
+
             {{- if .Values.configMaps }}
             volumeMounts:
             {{- range $v := .Values.configMaps }}

--- a/charts/cron-job/templates/rbacrole.yaml
+++ b/charts/cron-job/templates/rbacrole.yaml
@@ -6,16 +6,18 @@ metadata:
   labels:
     {{- include "snowplow.labels" $ | nindent 4 }}
 rules:
+{{- range $d := .Values.customRole.definition }}
 - apiGroups:
-  {{- range $v := .Values.customRole.apiGroups }}
+  {{- range $v := $d.apiGroups }}
   - {{ $v | quote }}
   {{- end }}
   resources:
-  {{- range $v := .Values.customRole.resources }}
+  {{- range $v := $d.resources }}
   - {{ $v | quote }}
   {{- end }}
   verbs:
-  {{- range $v := .Values.customRole.verbs }}
+  {{- range $v := $d.verbs }}
   - {{ $v | quote }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -88,17 +88,21 @@ cloudserviceaccount:
 customRole:
   # -- Whether to deploy the custom role and bind it to the cloudserviceaccount
   deploy: false
-
-  # -- APIGroups is the name of the APIGroup that contains the resources
-  apiGroups: []
-  #  - ""
-  # -- Resources is a list of resources this rule applies to
-  resources: []
-  #  - "configmaps"
-  # -- Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule
-  verbs: []
-  #  - "get"
-  #  - "create"
-  #  - "update"
-  #  - "patch"
-  #  - "delete"
+  # -- Array of role definitions to setup for the custom role
+  definition: []
+    # - apiGroups:
+    #     - ""
+    #   resources:
+    #     - "configmaps"
+    #   verbs:
+    #     - "get"
+    #     - "create"
+    #     - "update"
+    #     - "patch"
+    #     - "delete"
+    # - apiGroups:
+    #     - ""
+    #   resources:
+    #     - "pods"
+    #   verbs:
+    #     - "get"

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -49,6 +49,15 @@ configMaps: []
 #        contentsB64: "" # The file contents which have already been base-64 encoded
 #        contentsFile: "" # The path to a local file (note: contentsB64 will take precedence if not-empty)
 
+# -- Map of resource constraints for the deployment
+resources: {}
+#  limits:
+#    cpu: 746m
+#    memory: 900Mi
+#  requests:
+#    cpu: 400m
+#    memory: 512Mi
+
 dockerconfigjson:
   # -- Name of the secret to use for the private repository
   name: "snowplow-cron-job-dockerhub"


### PR DESCRIPTION
makes it possible to specify resource allocations for cronjobs and also allows for fine-grained custom roles to be attached so that verbs can be split against resources.