### PR TITLE
charts/service-deployment: Add tlsSecretName override (closes #245)

### DIFF
--- a/charts/service-deployment/Chart.yaml
+++ b/charts/service-deployment/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: service-deployment
 description: A Helm Chart to setup a generic deployment with optional service/hpa bindings
-version: 0.24.0
+version: 0.25.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/service-deployment/templates/certificate.yaml
+++ b/charts/service-deployment/templates/certificate.yaml
@@ -1,5 +1,5 @@
 {{- range .Values.service.ingress }}
-{{- if .certificateCreate  | default "true" }}
+{{- if and (.certificateCreate  | default "true") (not .tlsSecretName) }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/charts/service-deployment/templates/ingress.yaml
+++ b/charts/service-deployment/templates/ingress.yaml
@@ -23,7 +23,7 @@ spec:
   tls:
   - hosts:
       - "{{ .hostname }}"
-    secretName: {{ .hostname }}-tls
+    secretName: {{ if .tlsSecretName }}{{ .tlsSecretName }}{{ else }}{{ .hostname }}-tls{{ end }}
   rules:
     - host: "{{ required "A valid hostname is required!" .hostname }}"
       http:

--- a/charts/service-deployment/values.yaml
+++ b/charts/service-deployment/values.yaml
@@ -139,6 +139,7 @@ service:
     #   certificateIssuerName: cloudflare # -- What issuer to use for the Certificate (default: letsencrypt-staging)
     #   certificateIssuerKind: Issuer # -- Kind of issuer (default: ClusterIssuer)
     #   enableTraefik: false # -- Enables traefik annotations and set ingressClassName. (default: true)
+    #   tlsSecretName: qa1-tracking-snowplow-io-tls # -- Override TLS secret name (optional, defaults to {hostname}-tls)
     #   annotations: {} # -- Map of annotations to add to the ingress
   # -- List of IP addresses to restrict ingress traffic to
   ingressIPAllowlist: []


### PR DESCRIPTION
This PR updates the service-deployment chart to
- Allow optional TLS secret name override to reference an already existing secret
- Not deploy Cert-Manager certificate if `tlsSecretName` is set in ingress