### PR TITLE
TECOPS-15010: DB Bootstrap job

### DIFF
--- a/charts/service-deployment/templates/db-bootstrap-hook.yaml
+++ b/charts/service-deployment/templates/db-bootstrap-hook.yaml
@@ -1,0 +1,97 @@
+{{- if .Values.databaseBootstrap.enabled }}
+{{- if .Values.config.secrets }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "app.fullname" . }}-db-bootstrap-secret
+  labels:
+    {{- include "snowplow.labels" . | nindent 4 }}
+    app.kubernetes.io/component: db-bootstrap
+  annotations:
+    "helm.sh/hook": {{ .Values.databaseBootstrap.hookPhase }}
+    "helm.sh/hook-delete-policy": {{ .Values.databaseBootstrap.hookDeletePolicy }}
+    "helm.sh/hook-weight": "0"
+type: Opaque
+data:
+  {{- range $k, $v := .Values.config.secrets }}
+  {{ $k }}: {{ $v | b64enc | quote }}
+  {{- end }}
+{{- end }}
+{{- if .Values.databaseBootstrap.sqlScripts }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "app.fullname" . }}-db-bootstrap-sql
+  labels:
+    {{- include "snowplow.labels" . | nindent 4 }}
+    app.kubernetes.io/component: db-bootstrap
+  annotations:
+    "helm.sh/hook": {{ .Values.databaseBootstrap.hookPhase }}
+    "helm.sh/hook-delete-policy": {{ .Values.databaseBootstrap.hookDeletePolicy }}
+    "helm.sh/hook-weight": "1"
+data:
+  {{- range .Values.databaseBootstrap.sqlScripts }}
+  {{ .name }}: |
+{{ .content | nindent 4 }}
+  {{- end }}
+{{- end }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "app.fullname" . }}-db-bootstrap
+  labels:
+    {{- include "snowplow.labels" . | nindent 4 }}
+    app.kubernetes.io/component: db-bootstrap
+  annotations:
+    "helm.sh/hook": {{ .Values.databaseBootstrap.hookPhase }}
+    "helm.sh/hook-delete-policy": {{ .Values.databaseBootstrap.hookDeletePolicy }}
+    "helm.sh/hook-weight": "2"
+spec:
+  backoffLimit: {{ .Values.databaseBootstrap.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.databaseBootstrap.activeDeadlineSeconds }}
+  template:
+    metadata:
+      name: {{ include "app.fullname" . }}-db-bootstrap
+      labels:
+        {{- include "snowplow.labels" . | nindent 8 }}
+        app.kubernetes.io/component: db-bootstrap
+    spec:
+      restartPolicy: Never
+      {{- if .Values.databaseBootstrap.sqlScripts }}
+      volumes:
+      - name: sql-scripts
+        configMap:
+          name: {{ include "app.fullname" . }}-db-bootstrap-sql
+      {{- end }}
+      containers:
+      - name: db-bootstrap
+        image: {{ .Values.databaseBootstrap.image }}
+        command: ["/bin/sh", "-c"]
+        args:
+        - {{ .Values.databaseBootstrap.script | quote }}
+        {{- if .Values.config.env }}
+        env:
+        {{- range $k, $v := .Values.config.env }}
+        - name: "{{ $k }}"
+          value: "{{ $v }}"
+        {{- end }}
+        {{- end }}
+        {{- if .Values.config.secrets }}
+        envFrom:
+        - secretRef:
+            name: {{ include "app.fullname" . }}-db-bootstrap-secret
+        {{- end }}
+        {{- with .Values.databaseBootstrap.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- if .Values.databaseBootstrap.sqlScripts }}
+        volumeMounts:
+        - name: sql-scripts
+          mountPath: /bootstrap-sql
+          readOnly: true
+        {{- end }}
+{{- end }}

--- a/charts/service-deployment/values.yaml
+++ b/charts/service-deployment/values.yaml
@@ -104,12 +104,12 @@ hpa:
   maxReplicas: 20
   # -- Default average CPU utilization before auto-scaling starts
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 75
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
   behavior: {}
 
 service:
@@ -130,7 +130,8 @@ service:
   # -- Map of annotations to add to the service
   annotations: {}
   # -- A map of ingress rules to deploy
-  ingress: {}
+  ingress:
+    {}
     # ingress-0001:
     #   hostname: example-01.com
     # ingress-0002:
@@ -188,7 +189,8 @@ deployment:
       # -- The maximum number or precent of pods that can be created in addition to the current number of pods during the rolling update. Can be set as number "5" for 5 additional pods
       maxSurge: "25%"
   # -- Map of labels that will be added to each pod in the deployment
-  podLabels: {}
+  podLabels:
+    {}
     # env: prod2
     # dept: engineering
 
@@ -260,3 +262,44 @@ persistentVolume:
   subPath: ""
   # -- Set to "-" or "" to disable dynamic provisioning, if undefined uses the default provisioner
   # storageClass: "-"
+
+# Database Bootstrap Hook Configuration
+databaseBootstrap:
+  # -- Whether to enable the database bootstrap hook
+  enabled: false
+  # -- Script to execute in the bootstrap job
+  script: |
+    echo "Starting database bootstrap..."
+    # Your bootstrap logic here
+    echo "Bootstrap completed!"
+  # -- Image to use for bootstrap job (defaults to postgres:alpine for DB operations)
+  image: postgres:alpine
+  # -- When to run the hook (pre-install or pre-install,pre-upgrade)
+  hookPhase: "pre-install"
+  # -- Hook deletion policy (hook-succeeded, hook-failed, or before-hook-creation)
+  hookDeletePolicy: "before-hook-creation"
+  # -- Maximum number of retries before marking job as failed
+  backoffLimit: 3
+  # -- Maximum time in seconds for the job to run
+  activeDeadlineSeconds: 300
+  # -- Optional SQL scripts to mount at /bootstrap-sql/
+  sqlScripts:
+    []
+    # - name: "01-create-schema.sql"
+    #   content: |
+    #     CREATE SCHEMA IF NOT EXISTS myschema;
+    # - name: "02-create-tables.sql"
+    #   content: |
+    #     CREATE TABLE IF NOT EXISTS myschema.mytable (
+    #       id SERIAL PRIMARY KEY,
+    #       name VARCHAR(255)
+    #     );
+  # -- Resource limits for the bootstrap job
+  resources:
+    {}
+    # limits:
+    #   cpu: 200m
+    #   memory: 256Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi


### PR DESCRIPTION
## Summary
Adds an optional database bootstrap hook to the service-deployment Helm chart for initializing PostgreSQL databases from within Kubernetes clusters. This addresses the need to bootstrap databases (like Feast Registry) when PostgreSQL instances are deployed in private networks via aws_rds/gcp_cloudsql stacks.

## Key Changes
- Added `db-bootstrap-hook.yaml` template with Kubernetes Job, Secret, and ConfigMap resources
- Extended `values.yaml` with comprehensive bootstrap configuration options
- Supports custom SQL script execution via ConfigMap mounting
- Configurable Helm hook lifecycle (pre-install/pre-upgrade)
- Includes retry logic, timeout settings, and resource limits
- Inherits environment variables and secrets from main deployment

## Hook Behavior
The default `hookPhase: "pre-install"` ensures the bootstrap job only runs during the initial `helm install`. It will not run on subsequent `helm upgrade` commands, preventing duplicate database initialization. If re-initialization is needed on upgrades, users can set `hookPhase: "pre-install,pre-upgrade"`.

### Test Setup
Deployed the chart with database bootstrap enabled to AWS EKS cluster in `aws-sandbox-dev1` namespace, targeting an RDS PostgreSQL instance in a private subnet. I used the aws_feast stack, along with the helm_feast_feature_server module to test this. This required adding an aws_rds_outputs module, along with some template modifications. 

### Verification Steps
1. **Hook Execution**: Confirmed bootstrap job ran successfully as pre-install hook
2. **Database Connectivity**: Verified connection from within Kubernetes cluster to private RDS instance
3. **Schema Creation**: Confirmed `feast_registry` schema was created
4. **User Creation**: Verified `feast_user` was created with appropriate privileges
5. **Idempotency**: Re-ran bootstrap script, confirmed it handled existing resources gracefully

Jira Ticket: [TECOPS-15010](https://snplow.atlassian.net/browse/TECOPS-15010)