### PR TITLE
Adds pod filtering logic to avoid creating excessive metrics in cloudwatch

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.96 (2025-09-22)
+---------------------------
+charts/aws-otel-collector: Add pod exclusion filter support to reduce CloudWatch costs (#379)
+
 Version 0.1.95 (2025-09-08)
 ---------------------------
 charts/service-deployment: Add vertical pod autoscaler support (#188)

--- a/charts/aws-otel-collector/Chart.yaml
+++ b/charts/aws-otel-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-otel-collector
 description: A Helm chart to deploy aws-otel-collector project
-version: 0.6.0
+version: 0.7.0
 appVersion: "v0.33.1"
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts

--- a/charts/aws-otel-collector/templates/configmap.yaml
+++ b/charts/aws-otel-collector/templates/configmap.yaml
@@ -17,6 +17,15 @@ data:
     processors:
       batch/metrics:
         timeout: 60s
+{{- if .Values.excludedPodPatterns }}
+      filter/exclude_pods:
+        error_mode: ignore
+        metrics:
+          metric:
+{{- range .Values.excludedPodPatterns }}
+            - 'IsMatch(resource.attributes["PodName"], "{{ . }}")'
+{{- end }}
+{{- end }}
 
     exporters:
       awsemf:
@@ -55,7 +64,7 @@ data:
       pipelines:
         metrics:
           receivers: [awscontainerinsightreceiver]
-          processors: [batch/metrics]
+          processors: [{{- if .Values.excludedPodPatterns }}filter/exclude_pods, {{- end }}batch/metrics]
           exporters: [awsemf]
 
       extensions: [health_check]
@@ -91,6 +100,15 @@ data:
     processors:
       batch/metrics:
         timeout: 60s
+{{- if .Values.excludedPodPatterns }}
+      filter/exclude_pods:
+        error_mode: ignore
+        metrics:
+          metric:
+{{- range .Values.excludedPodPatterns }}
+            - 'IsMatch(resource.attributes["PodName"], "{{ . }}")'
+{{- end }}
+{{- end }}
       resourcedetection/ec2:
         detectors: [ env ]
         timeout: 2s
@@ -162,7 +180,7 @@ data:
       pipelines:
         metrics:
           receivers: [awscontainerinsightreceiver]
-          processors: [batch/metrics]
+          processors: [{{- if .Values.excludedPodPatterns }}filter/exclude_pods, {{- end }}batch/metrics]
           exporters: [awsemf]
         metrics/prometheus:
           receivers: [prometheus]

--- a/charts/aws-otel-collector/values.yaml
+++ b/charts/aws-otel-collector/values.yaml
@@ -37,3 +37,7 @@ prometheus_log_retention_in_days: 30
 
 # -- Set tags to log groups created by otel collector awsemfexporter
 tags: {}
+
+# -- List of regexp patterns to exclude pods from Container Insights metrics collection
+# Example: [".*kclmon-cron.*", ".*metrics-relay.*"]
+excludedPodPatterns: []


### PR DESCRIPTION
# Add Pod Exclusion Support to aws-otel-collector Helm Chart

## Summary
Adds configurable pod exclusion filtering to reduce CloudWatch Container Insights costs by excluding short-lived pods like `kclmon-cron` and `metrics-relay` from metrics collection.

## Problem
Container Insights collects metrics for all pods, including frequently rotating CronJob pods that provide no operational value but increase CloudWatch costs.

## Solution
Added OpenTelemetry filter processor with configurable regex patterns:

**Configuration (`values.yaml`):**
```yaml
excludedPodPatterns: [".*kclmon-cron.*", ".*metrics-relay.*"]
```

**Implementation:**
- Filter processor matches on `resource.attributes["PodName"]`
- Runs before batch processor in pipeline
- Backward compatible (empty array = no filtering)

## Testing
Validated on EKS cluster with multiple patterns:
- ✅ Metrics stopped immediately when filter applied
- ✅ Metrics resumed when filter removed  
- ✅ Multiple patterns work correctly
- ✅ Other cluster metrics unaffected

Screenshot of turning metrics for ebs-csi-node pods on and off in consul
<img width="2670" height="1331" alt="image" src="https://github.com/user-attachments/assets/fc871918-c5f1-46cc-8013-b808209a2d2f" />

## Impact
- Reduces CloudWatch costs by filtering non-essential pod metrics
- Zero impact on operational visibility
- Configurable per environment