### PR TITLE
charts/aws-otel-collector: Add total bytes transmitted egress metric

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.1.100 (2025-10-17)
+---------------------------
+charts/aws-otel-collector: Add total bytes transmitted egress metric (#270)
+
 Version 0.1.99 (2025-10-15)
 ---------------------------
 charts/common: Initial release of common library chart with reusable template helpers

--- a/charts/aws-otel-collector/Chart.yaml
+++ b/charts/aws-otel-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-otel-collector
 description: A Helm chart to deploy aws-otel-collector project
-version: 0.7.0
+version: 0.8.0
 appVersion: "v0.33.1"
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts

--- a/charts/aws-otel-collector/templates/configmap.yaml
+++ b/charts/aws-otel-collector/templates/configmap.yaml
@@ -50,6 +50,7 @@ data:
               - pod_number_of_container_restarts
               - pod_cpu_reserved_capacity
               - pod_memory_reserved_capacity
+              - pod_network_tx_bytes
           - dimensions: [[FullPodName, Namespace, ClusterName]]
             metric_name_selectors:
               - pod_cpu_utilization
@@ -145,6 +146,7 @@ data:
               - pod_number_of_container_restarts
               - pod_cpu_reserved_capacity
               - pod_memory_reserved_capacity
+              - pod_network_tx_bytes
           - dimensions: [[FullPodName, Namespace, ClusterName]]
             metric_name_selectors:
               - pod_cpu_utilization


### PR DESCRIPTION
This PR adds an additional metric `pod_network_tx_bytes` to be scraped and pushed to Cloudwatch with PodName, Namespace, ClusterName dimensions.  

Test install usinf `helm install test . --dry-run --debug` shows that new metric is added in both situations (cut down version)

### kube_state_metrics_enabled = false

```bash
---
# Source: aws-otel-collector/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test
  labels:
    helm.sh/chart: test-0.8.0
    app.kubernetes.io/name: test
    app.kubernetes.io/version: "v0.33.1"
    app.kubernetes.io/managed-by: Helm
data:
  otel-agent-config: |
    extensions:
      health_check:

    receivers:
      awscontainerinsightreceiver:
        add_full_pod_name_metric_label: true

    processors:
      batch/metrics:
        timeout: 60s

    exporters:
      awsemf:
        namespace: ContainerInsights
        log_group_name: '/aws/containerinsights//performance'
        log_stream_name: '{NodeName}'
        log_retention: 30
        resource_to_telemetry_conversion:
          enabled: true
        dimension_rollup_option: NoDimensionRollup
        parse_json_encoded_attr_values: [Sources, kubernetes]
        metric_declarations:
          - dimensions: [[PodName, Namespace, ClusterName]]
            metric_name_selectors:
              - pod_cpu_utilization
              - pod_memory_utilization
              - pod_number_of_running_containers
              - pod_number_of_container_restarts
              - pod_cpu_reserved_capacity
              - pod_memory_reserved_capacity
              - pod_network_tx_bytes
          - dimensions: [[FullPodName, Namespace, ClusterName]]
            metric_name_selectors:
              - pod_cpu_utilization
              - pod_memory_utilization
          - dimensions: [[ClusterName]]
            metric_name_selectors:
              - cluster_node_count
              - node_cpu_utilization
              - node_memory_utilization

    service:
      pipelines:
        metrics:
          receivers: [awscontainerinsightreceiver]
          processors: [batch/metrics]
          exporters: [awsemf]

      extensions: [health_check]
---
```

### kube_state_metrics_enabled = true

```bash
---
# Source: aws-otel-collector/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test
  labels:
    helm.sh/chart: test-0.8.0
    app.kubernetes.io/name: test
    app.kubernetes.io/version: "v0.33.1"
    app.kubernetes.io/managed-by: Helm
data:
  otel-agent-config: |
    extensions:
      health_check:

    receivers:
      awscontainerinsightreceiver:
        add_full_pod_name_metric_label: true
      prometheus:
        config:
          global:
            scrape_interval: 1m
            scrape_timeout: 10s
          scrape_configs:
            - job_name: kube-state-metrics
              honor_timestamps: true
              scrape_interval: 1m
              scrape_timeout: 1m
              metrics_path: /metrics
              scheme: http
              static_configs:
                - targets:
                  - prometheus-kube-state-metrics.monitoring.svc.cluster.local:8080
                  labels:
                    cluster_name: 
              metric_relabel_configs:
                - source_labels: [__name__]
                  regex: "^kube_deployment_status_replicas_ready$"
                  action: keep

    processors:
      batch/metrics:
        timeout: 60s
      resourcedetection/ec2:
        detectors: [ env ]
        timeout: 2s
        override: false
      resource:
        attributes:
          - key: TaskId
            from_attribute: service.name
            action: insert
          - key: receiver
            value: "prometheus"
            action: insert

    exporters:
      awsemf:
        namespace: ContainerInsights
        log_group_name: '/aws/containerinsights//performance'
        log_stream_name: '{NodeName}'
        log_retention: 30
        resource_to_telemetry_conversion:
          enabled: true
        dimension_rollup_option: NoDimensionRollup
        parse_json_encoded_attr_values: [Sources, kubernetes]
        metric_declarations:
          - dimensions: [[PodName, Namespace, ClusterName]]
            metric_name_selectors:
              - pod_cpu_utilization
              - pod_memory_utilization
              - pod_number_of_running_containers
              - pod_number_of_container_restarts
              - pod_cpu_reserved_capacity
              - pod_memory_reserved_capacity
              - pod_network_tx_bytes
          - dimensions: [[FullPodName, Namespace, ClusterName]]
            metric_name_selectors:
              - pod_cpu_utilization
              - pod_memory_utilization
          - dimensions: [[ClusterName]]
            metric_name_selectors:
              - cluster_node_count
              - node_cpu_utilization
              - node_memory_utilization

      awsemf/prometheus:
        namespace: ContainerInsights/Prometheus
        log_group_name: '/aws/containerinsights//{TaskId}/prometheus'
        log_stream_name: "{TaskId}"
        log_retention: 30
        resource_to_telemetry_conversion:
          enabled: true
        dimension_rollup_option: NoDimensionRollup
        metric_declarations:
        - dimensions: [[ namespace, deployment, cluster_name ]]
          metric_name_selectors:
            - "^kube_deployment_status_replicas_ready$"
          label_matchers:
            - label_names:
                - service.name
              regex: ^kube-state-metrics$

    service:
      pipelines:
        metrics:
          receivers: [awscontainerinsightreceiver]
          processors: [batch/metrics]
          exporters: [awsemf]
        metrics/prometheus:
          receivers: [prometheus]
          processors: [resourcedetection/ec2, resource]
          exporters: [awsemf/prometheus]

      extensions: [health_check]
---
```
