### PR TITLE
charts/cert-manager-issuer update cert-manager-crds version dependency

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.3.4 (2025-10-24)
+---------------------------
+charts/cert-manager-issuer: Add compatibility with charts/cert-manager-crds (v1.19.x)
+
 Version 0.3.3 (2025-10-23)
 ---------------------------
 charts/cert-manager-crds: Add compatibility with the latest cert-manager version (v1.19.x) (#274)

--- a/charts/cert-manager-issuer/Chart.lock
+++ b/charts/cert-manager-issuer/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cert-manager-crds
   repository: https://snowplow-devops.github.io/helm-charts
-  version: 0.1.0
-digest: sha256:210597b039bc002fc20ec5908bce2dc1f74482edfbae7158f1e64c46ee2ddc70
-generated: "2023-10-17T16:01:40.362986-04:00"
+  version: 0.2.0
+digest: sha256:1fd1f1eca04ed9295a96cb2ab7b416bd013a4cf0ce6c702ef1b284401fa83b6b
+generated: "2025-10-24T10:37:19.523366+01:00"

--- a/charts/cert-manager-issuer/Chart.yaml
+++ b/charts/cert-manager-issuer/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v2
 name: cert-manager-issuer
 description: A helm chart that creates an Issuer or ClusterIssuer for cert-manager
-version: 0.2.0
+version: 0.3.0
+appVersion: "v1.19.1"
 type: application
 home: https://github.com/snowplow-devops/helm-charts
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
@@ -19,5 +20,5 @@ keywords:
   - nlb
 dependencies:
   - name: cert-manager-crds
-    version: 0.1.0
+    version: 0.2.0
     repository: "https://snowplow-devops.github.io/helm-charts"


### PR DESCRIPTION
This update modifies the cert-manager-issuer dependency version for cert-manager-crds to support cert-manager v1.19.