### PR TITLE
charts/cron-job: Add ttlSecondsAfterFinished support for completed/failed jobs to be garbage collected

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.3.18 (2026-02-13)
+---------------------------
+charts/cron-job-0.14.0: Add ttlSecondsAfterFinished support for completed/failed jobs to be garbage collected (#303)
+
 Version 0.3.17 (2026-01-14)
 ---------------------------
 charts/avalanche-0.1.0: Add Avalanche chart - progressive load testing framework for Snowplow infrastructure (#301)

--- a/charts/cron-job/Chart.yaml
+++ b/charts/cron-job/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cron-job
 description: A Helm Chart to deploy an arbitrary container as a cron job.
-version: 0.13.0
+version: 0.14.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/cron-job/README.md
+++ b/charts/cron-job/README.md
@@ -46,6 +46,7 @@ helm delete cron-job
 | restartPolicy | string | `"Never"` |  |
 | failedJobsHistoryLimit | int | `1` |  |
 | successfulJobsHistoryLimit | int | `1` |  |
+| ttlSecondsAfterFinished | int | `nil` | TTL (in seconds) for cleaning up finished jobs (both failed and successful) |
 | backoffLimit | int | `6` | The number of retries to attempt before marking the job as failed |
 | activeDeadlineSeconds | int | `nil` | The number of seconds the job is allowed to run before being terminated (optional) |
 | image.repository | string | `"busybox"` |  |

--- a/charts/cron-job/templates/deployment.yaml
+++ b/charts/cron-job/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
 
   jobTemplate:
     spec:
+      {{- if $.Values.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ $.Values.ttlSecondsAfterFinished }}
+      {{- end }}
       backoffLimit: {{ $.Values.backoffLimit }}
       {{- if $.Values.activeDeadlineSeconds }}
       activeDeadlineSeconds: {{ $.Values.activeDeadlineSeconds }}

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -18,6 +18,8 @@ concurrencyPolicy: "Forbid"
 restartPolicy: "Never"
 failedJobsHistoryLimit: 1
 successfulJobsHistoryLimit: 1
+# -- TTL (in seconds) for cleaning up finished jobs (both failed and successful)
+# ttlSecondsAfterFinished: 604800  # 7 days
 # -- The number of retries to attempt before marking the job as failed
 backoffLimit: 6
 # -- The number of seconds the job is allowed to run before being terminated (optional)


### PR DESCRIPTION
Add support for `ttlSecondsAfterFinished` so that cron jobs can be garbage collected after a set period when they have completed or failed