### PR TITLE
charts/aws-otel-collector: add securityContext so v0.47.0+ can emit pod-level metrics (closes #322)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.3.31 (2026-04-22)
+---------------------------
+charts/aws-otel-collector-0.13.0: Add securityContext (runAsUser/runAsGroup=0) so v0.47.0+ can read containerd socket and emit pod-level metrics
+
 Version 0.3.30 (2026-04-21)
 ---------------------------
 charts/aws-otel-collector-0.12.0: Add RBAC for endpointslices and bump to v0.47.0

--- a/charts/aws-otel-collector/Chart.yaml
+++ b/charts/aws-otel-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-otel-collector
 description: A Helm chart to deploy aws-otel-collector project
-version: 0.12.0
+version: 0.13.0
 appVersion: "v0.47.0"
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts

--- a/charts/aws-otel-collector/templates/daemonset.yaml
+++ b/charts/aws-otel-collector/templates/daemonset.yaml
@@ -21,6 +21,13 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
 
+        # Required for awscontainerinsightreceiver to access the containerd socket
+        # (owned root:root 0660 on the host) so cAdvisor can enrich container stats
+        # with pod-level metadata. Without this, aws-otel-collector v0.47.0+ fails
+        # with "No pod metric collected" and no pod_* metrics are emitted.
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+
         env:
         - name: K8S_NODE_NAME
           valueFrom:

--- a/charts/aws-otel-collector/values.yaml
+++ b/charts/aws-otel-collector/values.yaml
@@ -14,9 +14,17 @@ image:
 # -- Pod/container securityContext for the collector. Defaults to running as root
 # (uid/gid 0) so awscontainerinsightreceiver can read the containerd socket on
 # EKS nodes (root:root 0660). Required for pod-level metrics on collector v0.47.0+.
+# Remaining fields tighten the context to satisfy restricted PodSecurity scanners
+# without giving up the root UID needed for the socket.
 securityContext:
   runAsUser: 0
   runAsGroup: 0
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  privileged: false
+  capabilities:
+    drop:
+      - ALL
 
 resources:
   limits:

--- a/charts/aws-otel-collector/values.yaml
+++ b/charts/aws-otel-collector/values.yaml
@@ -11,6 +11,13 @@ image:
   tag: v0.47.0
   pullPolicy: IfNotPresent
 
+# -- Pod/container securityContext for the collector. Defaults to running as root
+# (uid/gid 0) so awscontainerinsightreceiver can read the containerd socket on
+# EKS nodes (root:root 0660). Required for pod-level metrics on collector v0.47.0+.
+securityContext:
+  runAsUser: 0
+  runAsGroup: 0
+
 resources:
   limits:
     memory: 200Mi


### PR DESCRIPTION
Fixes #322. Follow-up to #321.

## Problem

After rolling out chart `0.12.0` (which pins image `v0.47.0`) to an AWS EKS sandbox, pod-level Container Insights metrics (`pod_cpu_utilization`, `pod_memory_utilization`, OOM counters, etc.) stopped being emitted cluster-wide. Node-level metrics and the Prometheus-receiver path (KSM scrape) kept working.

Observed in collector logs every minute on every daemonset pod:

```
warn  cadvisor/container_info_processor.go:81  "No pod metric collected"  {"metrics count": 35}
```

And at startup:

```
Registration of the containerd container factory failed: unable to create containerd client:
dial unix /run/containerd/containerd.sock: connect: permission denied
```

## Root cause

`awscontainerinsightreceiver` in `v0.47.0` requires containerd socket access to enrich container stats with pod metadata. The host socket `/run/containerd/containerd.sock` is `root:root 0660`. Our daemonset has no `securityContext`, so the container runs as the image's default non-root user (`aoc`, UID 1000) and can't read the socket. Older collector versions fell back to docker.sock / cgroups and didn't need containerd — this only surfaces from v0.47.0.

AWS's own reference daemonset ([upstream `otel-container-insights-infra.yaml`](https://github.com/aws-observability/aws-otel-collector/blob/main/deployment-template/eks/otel-container-insights-infra.yaml)) runs the collector as root.

## Changes

- `templates/daemonset.yaml` — add `securityContext` block, sourced from `.Values.securityContext` so users can override.
- `values.yaml` — default `securityContext: {runAsUser: 0, runAsGroup: 0}` with inline comment explaining why.
- `Chart.yaml` — `version` 0.12.0 → 0.13.0.
- `CHANGELOG` — new entry `0.3.31`.

## Verification

Will re-run on `sp-aws-sandbox-dev1-eks-cluster` after chart `0.13.0` is published: pod-level metrics should resume within a few minutes, the `No pod metric collected` warn should disappear, and the containerd permission-denied error at startup should no longer appear.