### PR TITLE
Add rate limiting Traefik Middleware support (closes #328)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.3.34 (2026-05-07)
+---------------------------
+charts/common-0.9.0: Add rate limiting Traefik Middleware support (closes #328)
+
 Version 0.3.33 (2026-04-29)
 ---------------------------
 charts/multi-service-deployment-0.7.0: Bump common dependency for ipAllowList Traefik Middleware update

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A library chart containing common template helpers for Snowplow Helm charts
 type: library
-version: 0.8.0
+version: 0.9.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -107,6 +107,7 @@ sharedIngress:
 - `common.sharedingress`: Generate shared Ingress resources with path-based routing to multiple services
 - `common.certificate`: Generate cert-manager Certificate resources
 - `common.ipallowlist`: Generate Traefik Middleware for IP allowlisting
+- `common.ratelimit`: Generate Traefik Middleware for rate limiting
 - `common.targetgroupbinding`: Generate AWS TargetGroupBinding resources
 
 ### RBAC Resources

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -49,3 +49,22 @@ Define the default NEG name for GCP deployments.
 {{- default .Release.Name .Values.service.gcp.networkEndpointGroupName -}}
 {{- end -}}
 
+{{/*
+Generate Traefik middleware list for ingress annotations.
+Usage: {{ include "common.traefik.middlewares" (dict "service" $service "namespace" $.Release.Namespace) }}
+*/}}
+{{- define "common.traefik.middlewares" -}}
+{{- $service := .service -}}
+{{- $namespace := .namespace -}}
+{{- $middlewares := list -}}
+{{- if $service.service.ingressIPAllowlist -}}
+  {{- $middlewares = append $middlewares (printf "%s-%s-ipallowlist@kubernetescrd" $namespace $service.name) -}}
+{{- end -}}
+{{- if and $service.service.rateLimit $service.service.rateLimit.enabled -}}
+  {{- $middlewares = append $middlewares (printf "%s-%s-rate-limit@kubernetescrd" $namespace $service.name) -}}
+{{- end -}}
+{{- if $middlewares -}}
+{{- join ", " $middlewares | quote -}}
+{{- end -}}
+{{- end }}
+

--- a/charts/common/templates/_ingress.yaml
+++ b/charts/common/templates/_ingress.yaml
@@ -20,8 +20,9 @@ metadata:
   {{- if .enableTraefik | default true }}
     traefik.ingress.kubernetes.io/router.entrypoints: "web, websecure"
   {{- end}}
-  {{- if $service.service.ingressIPAllowlist }}
-    traefik.ingress.kubernetes.io/router.middlewares: {{ $release.Namespace }}-{{ $service.name }}-ipallowlist@kubernetescrd
+  {{- $middlewares := include "common.traefik.middlewares" (dict "service" $service "namespace" $release.Namespace) }}
+  {{- if $middlewares }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ $middlewares }}
   {{- end }}
 spec:
   {{- if .enableTraefik | default true }}

--- a/charts/common/templates/_ratelimit.yaml
+++ b/charts/common/templates/_ratelimit.yaml
@@ -1,0 +1,39 @@
+{{- define "common.ratelimit" -}}
+{{- $global := .Values.global -}}
+{{- range $service := .Values.services }}
+{{- if and $service.service.rateLimit $service.service.rateLimit.enabled $service.service.ingress }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $service.name }}-rate-limit
+  labels:
+    {{- with $global.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  rateLimit:
+    average: {{ $service.service.rateLimit.average }}
+    burst: {{ $service.service.rateLimit.burst }}
+    period: {{ $service.service.rateLimit.period | quote }}
+    {{- if and $service.service.rateLimit.sourceCriterion $service.service.rateLimit.sourceCriterion.enabled }}
+    sourceCriterion:
+      {{- $type := $service.service.rateLimit.sourceCriterion.type | default "ipStrategy" }}
+      {{- if eq $type "ipStrategy" }}
+      ipStrategy:
+        depth: {{ $service.service.rateLimit.sourceCriterion.ipStrategy.depth | default 1 }}
+        {{- if $service.service.rateLimit.sourceCriterion.ipStrategy.excludedIPs }}
+        excludedIPs:
+          {{- range $ip := $service.service.rateLimit.sourceCriterion.ipStrategy.excludedIPs }}
+          - "{{ $ip }}"
+          {{- end }}
+        {{- end }}
+      {{- else if eq $type "requestHeaderName" }}
+      requestHeaderName: {{ required "requestHeaderName is required when type is requestHeaderName" $service.service.rateLimit.sourceCriterion.requestHeaderName }}
+      {{- else if eq $type "requestHost" }}
+      requestHost: true
+      {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
This PR updates the common chart

- Adds RateLimit middleware
- Updates Ingress to use helper template for traefik middlewares when there are multiple enabled


Example yaml


```
  global:
    cloud: aws
    labels:
      env: test

  services:
    - name: frontend
      image:
        repository: nginx
        tag: latest
        isRepositoryPublic: true
        pullPolicy: IfNotPresent
      config:
        env: {}
        secrets: {}
        secretsB64: {}
        sharedNamespaceConfigMaps: []
      configMaps: []
      resources: {}
      readinessProbe:
        httpGet:
          path: ""
        exec:
          command: []
      livenessProbe:
        httpGet:
          path: ""
          port: ""
        exec:
          command: []
      terminationGracePeriodSeconds: 60
      hpa:
        deploy: false
      vpa:
        enabled: false
      podDisruptionBudget:
        enabled: false
      service:
        deploy: true
        port: 80
        targetPort: 80
        protocol: TCP
        annotations: {}
        ingress:
          main:
            hostname: example.com
        ingressIPAllowlist:
          - 10.0.0.0/8
          - 192.168.0.0/16
        rateLimit:
          enabled: true
          average: 100
          burst: 200
          period: "1m"
          sourceCriterion:
            enabled: true
            type: ipStrategy
            ipStrategy:
              depth: 1
              excludedIPs:
                - 127.0.0.1/32
      dockerconfigjson:
        name: my-dockerhub
      cloudserviceaccount:
        deploy: false
      deployment:
        kind: Deployment
        replicas: 1
        scaleToZero: false
        strategy:
          type: RollingUpdate
          rollingUpdate:
            maxUnavailable: "25%"
            maxSurge: "25%"
        podLabels: {}
        podAnnotations: {}
      persistentVolume:
        enabled: false
      hooks: {}
```


Output

```
 helm template my-app charts/multi-service-deployment \
    -f /tmp/multi-svc-rate-limit-test.yaml \
    --namespace apps
---
<TRUNCATED>
---
# Source: multi-service-deployment/templates/resources.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: example-com
  labels:
    env: test
  annotations:
    traefik.ingress.kubernetes.io/router.entrypoints: "web, websecure"
    traefik.ingress.kubernetes.io/router.middlewares: "apps-frontend-ipallowlist@kubernetescrd, apps-frontend-rate-limit@kubernetescrd"
spec:
  ingressClassName: traefik
  tls:
  - hosts:
      - "example.com"
    secretName: example-com-tls
  rules:
    - host: "example.com"
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name:  frontend
                port:
                  number: 80
---
# Source: multi-service-deployment/templates/resources.yaml
apiVersion: traefik.io/v1alpha1
kind: Middleware
metadata:
  name: frontend-ipallowlist
  labels:
    env: test
spec:
  ipAllowList:
    sourceRange:
      - "10.0.0.0/8"
      - "192.168.0.0/16"
---
# Source: multi-service-deployment/templates/resources.yaml
apiVersion: traefik.io/v1alpha1
kind: Middleware
metadata:
  name: frontend-rate-limit
  labels:
    env: test
spec:
  rateLimit:
    average: 100
    burst: 200
    period: "1m"
    sourceCriterion:
      ipStrategy:
        depth: 1
        excludedIPs:
          - "127.0.0.1/32"
          - ```