### PR TITLE
[QA-822] charts/avalanche-0.5.0: CloudWatch observer + entity-aware aggregator

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.3.38 (2026-05-29)
+---------------------------
+charts/avalanche-0.5.0: New deployments aggregator-kinesis-stream, mock-target (+ service); observer-kubernetes split into separate api / cloudwatch deployments sharing one ServiceAccount with optional IRSA annotation. New top-level values aggregatorKinesisStream, mockTarget, legacyMode. observerKubernetes.cloudwatch.targets[] gains kind, podNamePattern, podNameReplacement; observerKubernetes.config gains podNamePattern, podNameReplacement. aggregatorKubernetes.config.groupBy adds role; field whitelist extended with cpu_usage_percent_of_limit, memory_usage_percent_of_limit, cpu_usage_percent_of_cluster, memory_usage_percent_of_cluster, network_tx_bytes, container_restarts; spread aggregation added. New optional injector.gomaxprocs value pins GOMAXPROCS to the cgroup CPU limit. BREAKING: removes observerKubernetes.mode in favour of observerKubernetes.api.enabled + observerKubernetes.cloudwatch.enabled sub-toggles.
+
 Version 0.3.37 (2026-05-26)
 ---------------------------
 charts/aws-otel-collector-0.14.0: Bump version used to 0.48.0 (#335)

--- a/charts/avalanche/Chart.yaml
+++ b/charts/avalanche/Chart.yaml
@@ -3,7 +3,7 @@ name: avalanche
 description: A Helm chart for Avalanche - Progressive load testing framework for Snowplow infrastructure
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 type: application
-version: 0.2.0
+version: 0.5.0
 appVersion: "1.0.0"
 keywords:
   - avalanche

--- a/charts/avalanche/templates/adjudicator-deployment.yaml
+++ b/charts/avalanche/templates/adjudicator-deployment.yaml
@@ -36,7 +36,9 @@ spec:
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           args:
             - "adjudicator"
+            {{- if .Values.legacyMode }}
             - "--config=/configs/adjudicator.yaml"
+            {{- end }}
             - "--rules-dir=/rules"
             - "--nats-url={{ include "avalanche.natsUrl" . }}"
             - "--component-id={{ .Values.adjudicator.componentId }}"
@@ -48,6 +50,10 @@ spec:
                   key: log_level
             - name: AVALANCHE_NATS_URL
               value: {{ include "avalanche.natsUrl" . | quote }}
+            {{- if not .Values.legacyMode }}
+            - name: AVALANCHE_MANAGED
+              value: "true"
+            {{- end }}
             {{- include "avalanche.databaseEnv" . | nindent 12 }}
             {{- include "avalanche.awsEnv" . | nindent 12 }}
           volumeMounts:

--- a/charts/avalanche/templates/aggregator-deployment.yaml
+++ b/charts/avalanche/templates/aggregator-deployment.yaml
@@ -36,7 +36,9 @@ spec:
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           args:
             - "aggregator"
+            {{- if .Values.legacyMode }}
             - "--config=/configs/aggregator.yaml"
+            {{- end }}
             - "--nats-url={{ include "avalanche.natsUrl" . }}"
             - "--component-id={{ .Values.aggregator.componentId }}"
           env:
@@ -47,6 +49,10 @@ spec:
                   key: log_level
             - name: AVALANCHE_NATS_URL
               value: {{ include "avalanche.natsUrl" . | quote }}
+            {{- if not .Values.legacyMode }}
+            - name: AVALANCHE_MANAGED
+              value: "true"
+            {{- end }}
             {{- include "avalanche.databaseEnv" . | nindent 12 }}
             {{- include "avalanche.awsEnv" . | nindent 12 }}
           volumeMounts:

--- a/charts/avalanche/templates/aggregator-kinesis-stream-deployment.yaml
+++ b/charts/avalanche/templates/aggregator-kinesis-stream-deployment.yaml
@@ -1,24 +1,24 @@
-{{- if .Values.aggregatorKubernetes.enabled }}
+{{- if .Values.aggregatorKinesisStream.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "avalanche.fullname" . }}-aggregator-kubernetes
+  name: {{ include "avalanche.fullname" . }}-aggregator-kinesis-stream
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snowplow.labels" . | nindent 4 }}
-    app.kubernetes.io/component: aggregator-kubernetes
+    app.kubernetes.io/component: aggregator-kinesis-stream
 spec:
-  replicas: {{ .Values.aggregatorKubernetes.replicas }}
+  replicas: {{ .Values.aggregatorKinesisStream.replicas }}
   selector:
     matchLabels:
       {{- include "avalanche.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: aggregator-kubernetes
+      app.kubernetes.io/component: aggregator-kinesis-stream
   template:
     metadata:
       labels:
         {{- include "snowplow.labels" . | nindent 8 }}
         {{- include "avalanche.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: aggregator-kubernetes
+        app.kubernetes.io/component: aggregator-kinesis-stream
     spec:
       {{- if .Values.cloudserviceaccount.deploy }}
       serviceAccount: {{ .Values.cloudserviceaccount.name }}
@@ -32,17 +32,13 @@ spec:
       - name: {{ .Values.dockerconfigjson.name }}
       containers:
         - name: aggregator
-          image: {{ include "avalanche.image" (dict "images" .Values.images "image" .Values.aggregatorKubernetes.image) }}
+          image: {{ include "avalanche.image" (dict "images" .Values.images "image" .Values.aggregatorKinesisStream.image) }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           args:
             - "aggregator"
-            # Always run in standalone mode with own config from ConfigMap.
-            # The kubernetes aggregator has static config (source measurement,
-            # output measurements, window duration) that doesn't benefit from
-            # managed mode config distribution.
-            - "--config=/configs/aggregator-kubernetes.yaml"
+            - "--config=/configs/aggregator-kinesis-stream.yaml"
             - "--nats-url={{ include "avalanche.natsUrl" . }}"
-            - "--component-id={{ .Values.aggregatorKubernetes.componentId }}"
+            - "--component-id={{ .Values.aggregatorKinesisStream.componentId }}"
           env:
             - name: AVALANCHE_LOG_LEVEL
               valueFrom:
@@ -57,7 +53,6 @@ spec:
             - name: config
               mountPath: /configs
               readOnly: true
-          # Liveness probe - check process is running and can reach NATS
           livenessProbe:
             exec:
               command:
@@ -68,7 +63,6 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3
-          # Readiness probe - component is ready when NATS is reachable
           readinessProbe:
             exec:
               command:
@@ -79,7 +73,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
           resources:
-            {{- toYaml .Values.aggregatorKubernetes.resources | nindent 12 }}
+            {{- toYaml .Values.aggregatorKinesisStream.resources | nindent 12 }}
       volumes:
         - name: config
           configMap:

--- a/charts/avalanche/templates/configmap.yaml
+++ b/charts/avalanche/templates/configmap.yaml
@@ -9,12 +9,21 @@ data:
   log_level: {{ .Values.images.logLevel | quote }}
   nats_url: {{ include "avalanche.natsUrl" . | quote }}
 
+  # Full component configs — used in legacy mode by pods directly (via --config flag)
+  # and in managed mode by the controller (read from disk, distributed over NATS).
+  # Pods in managed mode don't read these files — they receive config via NATS
+  # from the controller's distributeConfigs() step.
+
   {{- if .Values.injector.enabled }}
   injector.yaml: |
     type: {{ .Values.injector.config.type | quote }}
     name: {{ .Values.injector.config.name | quote }}
     config:
+      {{- if .Values.mockTarget.enabled }}
+      endpoint: "http://{{ include "avalanche.fullname" . }}-mock-target:{{ .Values.mockTarget.port }}"
+      {{- else }}
       endpoint: {{ .Values.injector.config.endpoint | quote }}
+      {{- end }}
       {{- if .Values.injector.config.protocol }}
       protocol: {{ .Values.injector.config.protocol | quote }}
       {{- end }}
@@ -27,10 +36,31 @@ data:
       {{- if .Values.injector.config.insecureSkipVerify }}
       insecure_skip_verify: {{ .Values.injector.config.insecureSkipVerify }}
       {{- end }}
+      {{- if .Values.injector.config.generator }}
+      generator:
+        {{- if .Values.injector.config.generator.preset }}
+        preset: {{ .Values.injector.config.generator.preset | quote }}
+        {{- end }}
+        {{- if .Values.injector.config.generator.seed }}
+        seed: {{ .Values.injector.config.generator.seed }}
+        {{- end }}
+      {{- end }}
   {{- end }}
 
   {{- if .Values.observer.enabled }}
   observer.yaml: |
+    {{- if .Values.mockTarget.enabled }}
+    type: "mockserver"
+    name: {{ .Values.observer.config.name | quote }}
+    config:
+      endpoint: "http://{{ include "avalanche.fullname" . }}-mock-target:{{ .Values.mockTarget.port }}"
+      {{- if .Values.observer.config.checkInterval }}
+      check_interval: {{ .Values.observer.config.checkInterval | quote }}
+      {{- end }}
+      {{- if .Values.observer.config.tolerance }}
+      tolerance: {{ .Values.observer.config.tolerance }}
+      {{- end }}
+    {{- else }}
     type: {{ .Values.observer.config.type | quote }}
     name: {{ .Values.observer.config.name | quote }}
     config:
@@ -49,6 +79,7 @@ data:
       {{- if .Values.observer.config.region }}
       region: {{ .Values.observer.config.region | quote }}
       {{- end }}
+    {{- end }}
   {{- end }}
 
   {{- if .Values.correlator.enabled }}
@@ -73,6 +104,7 @@ data:
       final_validation_timeout: {{ .Values.adjudicator.config.finalValidationTimeout | quote }}
   {{- end }}
 
+  # Controller config is generated in both modes (controller always needs its full config)
   {{- if .Values.controller.enabled }}
   controller.yaml: |
     type: {{ .Values.controller.config.type | quote }}
@@ -84,6 +116,7 @@ data:
       test_plans_dir: {{ .Values.controller.config.testPlansDir | quote }}
   {{- end }}
 
+  # Aggregator configs are generated in both modes (aggregators always need full config)
   {{- if .Values.aggregator.enabled }}
   aggregator.yaml: |
     type: {{ .Values.aggregator.config.type | quote }}
@@ -131,8 +164,35 @@ data:
         {{- end }}
   {{- end }}
 
+  {{- if .Values.aggregatorKinesisStream.enabled }}
+  aggregator-kinesis-stream.yaml: |
+    type: {{ .Values.aggregatorKinesisStream.config.type | quote }}
+    name: {{ .Values.aggregatorKinesisStream.config.name | quote }}
+    config:
+      source_measurement: {{ .Values.aggregatorKinesisStream.config.sourceMeasurement | quote }}
+      {{- if .Values.aggregatorKinesisStream.config.outputMeasurements }}
+      output_measurements:
+        window: {{ .Values.aggregatorKinesisStream.config.outputMeasurements.window | quote }}
+        phase: {{ .Values.aggregatorKinesisStream.config.outputMeasurements.phase | quote }}
+        run: {{ .Values.aggregatorKinesisStream.config.outputMeasurements.run | quote }}
+      {{- end }}
+      window_duration: {{ .Values.aggregatorKinesisStream.config.windowDuration | quote }}
+      group_by:
+        {{- range .Values.aggregatorKinesisStream.config.groupBy }}
+        - {{ . }}
+        {{- end }}
+      fields:
+        {{- range $field, $aggs := .Values.aggregatorKinesisStream.config.fields }}
+        {{ $field }}:
+          {{- range $aggs }}
+          - {{ . }}
+          {{- end }}
+        {{- end }}
+  {{- end }}
+
   # External stub configurations for Kubernetes test orchestration
   # These are used by the controller to coordinate with external component pods
+  # Generated in both modes
   {{- if .Values.injector.enabled }}
   external-injector.yaml: |
     type: "external"
@@ -165,8 +225,16 @@ data:
       timeout: "30s"
   {{- end }}
 
+  # Observer Kubernetes configs (QA-822). The api and cloudwatch observers
+  # are independent — each only renders if its sub-toggle is enabled. Both
+  # can run side-by-side; their NATS componentIds are suffixed -api / -cloudwatch
+  # so the controller can address each pod distinctly.
   {{- if .Values.observerKubernetes.enabled }}
-  observer-kubernetes.yaml: |
+
+  {{- if .Values.observerKubernetes.api.enabled }}
+  # api observer keeps the unsuffixed name for backwards compatibility with
+  # existing test plans that reference external-observer-kubernetes.yaml.
+  observer-kubernetes-api.yaml: |
     type: {{ .Values.observerKubernetes.config.type | quote }}
     name: {{ .Values.observerKubernetes.config.name | quote }}
     config:
@@ -186,6 +254,12 @@ data:
       field_selector: {{ .Values.observerKubernetes.config.fieldSelector | quote }}
       {{- end }}
       poll_interval: {{ .Values.observerKubernetes.config.pollInterval | quote }}
+      {{- if .Values.observerKubernetes.config.podNamePattern }}
+      pod_name_pattern: {{ .Values.observerKubernetes.config.podNamePattern | quote }}
+      {{- end }}
+      {{- if .Values.observerKubernetes.config.podNameReplacement }}
+      pod_name_replacement: {{ .Values.observerKubernetes.config.podNameReplacement | quote }}
+      {{- end }}
       metrics:
         pods: {{ .Values.observerKubernetes.config.metrics.pods }}
         deployments: {{ .Values.observerKubernetes.config.metrics.deployments }}
@@ -198,4 +272,49 @@ data:
     config:
       timeout: "30s"
       underlying_type: "kubernetes"
+  {{- end }}
+
+  {{- if .Values.observerKubernetes.cloudwatch.enabled }}
+  observer-kubernetes-cloudwatch.yaml: |
+    type: "cloudwatch"
+    name: "{{ .Values.observerKubernetes.config.name }}-cloudwatch"
+    config:
+      poll_interval: {{ .Values.observerKubernetes.cloudwatch.pollInterval | quote }}
+      targets:
+        {{- range .Values.observerKubernetes.cloudwatch.targets }}
+        - kind: {{ default "container_insights" .kind | quote }}
+          region: {{ .region | quote }}
+          {{- if or (eq (default "container_insights" .kind) "container_insights") .clusterName }}
+          {{- if .clusterName }}
+          cluster_name: {{ .clusterName | quote }}
+          {{- end }}
+          {{- if .namespace }}
+          namespace: {{ .namespace | quote }}
+          {{- end }}
+          {{- if .podNameInclude }}
+          pod_name_include: {{ .podNameInclude | quote }}
+          {{- end }}
+          {{- if .podNameExclude }}
+          pod_name_exclude: {{ .podNameExclude | quote }}
+          {{- end }}
+          {{- /* Per-target podNamePattern / podNameReplacement override
+                 the cloudwatch-level defaults. Defaults are applied via
+                 `default` so a target with neither set still gets the
+                 stable role-tag mapping. */}}
+          pod_name_pattern: {{ default $.Values.observerKubernetes.cloudwatch.podNamePattern .podNamePattern | quote }}
+          pod_name_replacement: {{ default $.Values.observerKubernetes.cloudwatch.podNameReplacement .podNameReplacement | quote }}
+          {{- end }}
+          {{- if .streamName }}
+          stream_name: {{ .streamName | quote }}
+          {{- end }}
+        {{- end }}
+
+  external-observer-kubernetes-cloudwatch.yaml: |
+    type: "external"
+    name: "{{ .Values.observerKubernetes.config.name }}-cloudwatch"
+    config:
+      timeout: "30s"
+      underlying_type: "cloudwatch"
+  {{- end }}
+
   {{- end }}

--- a/charts/avalanche/templates/configmap.yaml
+++ b/charts/avalanche/templates/configmap.yaml
@@ -41,7 +41,7 @@ data:
         {{- if .Values.injector.config.generator.preset }}
         preset: {{ .Values.injector.config.generator.preset | quote }}
         {{- end }}
-        {{- if .Values.injector.config.generator.seed }}
+        {{- if hasKey .Values.injector.config.generator "seed" }}
         seed: {{ .Values.injector.config.generator.seed }}
         {{- end }}
       {{- end }}
@@ -57,7 +57,7 @@ data:
       {{- if .Values.observer.config.checkInterval }}
       check_interval: {{ .Values.observer.config.checkInterval | quote }}
       {{- end }}
-      {{- if .Values.observer.config.tolerance }}
+      {{- if hasKey .Values.observer.config "tolerance" }}
       tolerance: {{ .Values.observer.config.tolerance }}
       {{- end }}
     {{- else }}
@@ -70,7 +70,7 @@ data:
       {{- if .Values.observer.config.checkInterval }}
       check_interval: {{ .Values.observer.config.checkInterval | quote }}
       {{- end }}
-      {{- if .Values.observer.config.tolerance }}
+      {{- if hasKey .Values.observer.config "tolerance" }}
       tolerance: {{ .Values.observer.config.tolerance }}
       {{- end }}
       {{- if .Values.observer.config.streamArn }}
@@ -227,8 +227,11 @@ data:
 
   # Observer Kubernetes configs (QA-822). The api and cloudwatch observers
   # are independent — each only renders if its sub-toggle is enabled. Both
-  # can run side-by-side; their NATS componentIds are suffixed -api / -cloudwatch
-  # so the controller can address each pod distinctly.
+  # can run side-by-side: the api observer keeps the base componentId (for
+  # backwards compatibility with existing test plans that reference
+  # external-observer-kubernetes.yaml), the cloudwatch observer's
+  # componentId is suffixed with "-cloudwatch" so its NATS subjects are
+  # distinct.
   {{- if .Values.observerKubernetes.enabled }}
 
   {{- if .Values.observerKubernetes.api.enabled }}

--- a/charts/avalanche/templates/configmap.yaml
+++ b/charts/avalanche/templates/configmap.yaml
@@ -287,7 +287,7 @@ data:
         {{- range .Values.observerKubernetes.cloudwatch.targets }}
         - kind: {{ default "container_insights" .kind | quote }}
           region: {{ .region | quote }}
-          {{- if or (eq (default "container_insights" .kind) "container_insights") .clusterName }}
+          {{- if eq (default "container_insights" .kind) "container_insights" }}
           {{- if .clusterName }}
           cluster_name: {{ .clusterName | quote }}
           {{- end }}
@@ -300,12 +300,21 @@ data:
           {{- if .podNameExclude }}
           pod_name_exclude: {{ .podNameExclude | quote }}
           {{- end }}
-          {{- /* Per-target podNamePattern / podNameReplacement override
-                 the cloudwatch-level defaults. Defaults are applied via
-                 `default` so a target with neither set still gets the
-                 stable role-tag mapping. */}}
-          pod_name_pattern: {{ default $.Values.observerKubernetes.cloudwatch.podNamePattern .podNamePattern | quote }}
-          pod_name_replacement: {{ default $.Values.observerKubernetes.cloudwatch.podNameReplacement .podNameReplacement | quote }}
+          {{- /* Per-target podNamePattern / podNameReplacement override the
+                 cloudwatch-level defaults. hasKey (not `default`) is used so
+                 a target can explicitly disable the regex layer with
+                 `podNamePattern: ""` — `default` would treat the empty
+                 string as unset and fall back to the cluster default. */}}
+          {{- if hasKey . "podNamePattern" }}
+          pod_name_pattern: {{ .podNamePattern | quote }}
+          {{- else }}
+          pod_name_pattern: {{ $.Values.observerKubernetes.cloudwatch.podNamePattern | quote }}
+          {{- end }}
+          {{- if hasKey . "podNameReplacement" }}
+          pod_name_replacement: {{ .podNameReplacement | quote }}
+          {{- else }}
+          pod_name_replacement: {{ $.Values.observerKubernetes.cloudwatch.podNameReplacement | quote }}
+          {{- end }}
           {{- end }}
           {{- if .streamName }}
           stream_name: {{ .streamName | quote }}

--- a/charts/avalanche/templates/correlator-deployment.yaml
+++ b/charts/avalanche/templates/correlator-deployment.yaml
@@ -36,7 +36,9 @@ spec:
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           args:
             - "correlator"
+            {{- if .Values.legacyMode }}
             - "--config=/configs/correlator.yaml"
+            {{- end }}
             - "--nats-url={{ include "avalanche.natsUrl" . }}"
             - "--component-id={{ .Values.correlator.componentId }}"
           # Note: Correlator in standalone/container mode communicates via NATS only
@@ -49,6 +51,10 @@ spec:
                   key: log_level
             - name: AVALANCHE_NATS_URL
               value: {{ include "avalanche.natsUrl" . | quote }}
+            {{- if not .Values.legacyMode }}
+            - name: AVALANCHE_MANAGED
+              value: "true"
+            {{- end }}
             {{- if .Values.correlator.metricsWriteIntervalSeconds }}
             - name: AVALANCHE_METRICS_WRITE_INTERVAL_SECONDS
               value: {{ .Values.correlator.metricsWriteIntervalSeconds | quote }}

--- a/charts/avalanche/templates/injector-deployment.yaml
+++ b/charts/avalanche/templates/injector-deployment.yaml
@@ -53,6 +53,16 @@ spec:
             - name: AVALANCHE_MANAGED
               value: "true"
             {{- end }}
+            {{- if .Values.injector.gomaxprocs }}
+            # QA-523 experiment: pin GOMAXPROCS to the cgroup CPU limit.
+            # Go defaults to runtime.NumCPU() which is the node's core count,
+            # not the cgroup limit — on a 2-core-limited pod scheduled on an
+            # 8-core node, the runtime spawns 8 OS threads that the kernel
+            # CFS-throttles, starving the single rateController goroutine
+            # and capping the achievable injection rate around 100 RPS.
+            - name: GOMAXPROCS
+              value: {{ .Values.injector.gomaxprocs | quote }}
+            {{- end }}
             {{- include "avalanche.databaseEnv" . | nindent 12 }}
             {{- include "avalanche.awsEnv" . | nindent 12 }}
           volumeMounts:

--- a/charts/avalanche/templates/injector-deployment.yaml
+++ b/charts/avalanche/templates/injector-deployment.yaml
@@ -36,7 +36,9 @@ spec:
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           args:
             - "injector"
+            {{- if .Values.legacyMode }}
             - "--config=/configs/injector.yaml"
+            {{- end }}
             - "--nats-url={{ include "avalanche.natsUrl" . }}"
             - "--component-id={{ .Values.injector.componentId }}"
           env:
@@ -47,6 +49,10 @@ spec:
                   key: log_level
             - name: AVALANCHE_NATS_URL
               value: {{ include "avalanche.natsUrl" . | quote }}
+            {{- if not .Values.legacyMode }}
+            - name: AVALANCHE_MANAGED
+              value: "true"
+            {{- end }}
             {{- include "avalanche.databaseEnv" . | nindent 12 }}
             {{- include "avalanche.awsEnv" . | nindent 12 }}
           volumeMounts:

--- a/charts/avalanche/templates/mock-target-deployment.yaml
+++ b/charts/avalanche/templates/mock-target-deployment.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.mockTarget.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "avalanche.fullname" . }}-mock-target
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "snowplow.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mock-target
+spec:
+  replicas: {{ .Values.mockTarget.replicas }}
+  selector:
+    matchLabels:
+      {{- include "avalanche.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: mock-target
+  template:
+    metadata:
+      labels:
+        {{- include "snowplow.labels" . | nindent 8 }}
+        {{- include "avalanche.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: mock-target
+    spec:
+      {{- if .Values.cloudserviceaccount.deploy }}
+      serviceAccount: {{ .Values.cloudserviceaccount.name }}
+      serviceAccountName: {{ .Values.cloudserviceaccount.name }}
+      {{- else }}
+      serviceAccount: ""
+      serviceAccountName: ""
+      {{- end }}
+      automountServiceAccountToken: true
+      imagePullSecrets:
+      - name: {{ .Values.dockerconfigjson.name }}
+      containers:
+        - name: mock-target
+          image: {{ include "avalanche.image" (dict "images" .Values.images "image" .Values.mockTarget.image) }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.mockTarget.port }}
+              protocol: TCP
+          env:
+            - name: AVALANCHE_LOG_LEVEL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "avalanche.fullname" . }}-config
+                  key: log_level
+            - name: AVALANCHE_MOCK_TARGET_PORT
+              value: {{ .Values.mockTarget.port | quote }}
+          livenessProbe:
+            httpGet:
+              path: /stats
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /stats
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.mockTarget.resources | nindent 12 }}
+      restartPolicy: Always
+{{- end }}

--- a/charts/avalanche/templates/mock-target-service.yaml
+++ b/charts/avalanche/templates/mock-target-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.mockTarget.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "avalanche.fullname" . }}-mock-target
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "snowplow.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mock-target
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.mockTarget.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "avalanche.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: mock-target
+{{- end }}

--- a/charts/avalanche/templates/observer-deployment.yaml
+++ b/charts/avalanche/templates/observer-deployment.yaml
@@ -36,7 +36,9 @@ spec:
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           args:
             - "observer"
+            {{- if .Values.legacyMode }}
             - "--config=/configs/observer.yaml"
+            {{- end }}
             - "--nats-url={{ include "avalanche.natsUrl" . }}"
             - "--component-id={{ .Values.observer.componentId }}"
           env:
@@ -47,6 +49,10 @@ spec:
                   key: log_level
             - name: AVALANCHE_NATS_URL
               value: {{ include "avalanche.natsUrl" . | quote }}
+            {{- if not .Values.legacyMode }}
+            - name: AVALANCHE_MANAGED
+              value: "true"
+            {{- end }}
             {{- include "avalanche.databaseEnv" . | nindent 12 }}
             {{- include "avalanche.awsEnv" . | nindent 12 }}
           volumeMounts:

--- a/charts/avalanche/templates/observer-kubernetes-deployment.yaml
+++ b/charts/avalanche/templates/observer-kubernetes-deployment.yaml
@@ -1,42 +1,47 @@
 {{- if .Values.observerKubernetes.enabled }}
+{{- if .Values.observerKubernetes.api.enabled }}
+# observer-kubernetes (api): native K8s observer reading pod / deployment /
+# event / resource metrics from the in-cluster Kubernetes API + metrics-server.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "avalanche.fullname" . }}-observer-kubernetes
+  name: {{ include "avalanche.fullname" . }}-observer-kubernetes-api
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snowplow.labels" . | nindent 4 }}
-    app.kubernetes.io/component: observer-kubernetes
+    app.kubernetes.io/component: observer-kubernetes-api
 spec:
   replicas: {{ .Values.observerKubernetes.replicas }}
   selector:
     matchLabels:
       {{- include "avalanche.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: observer-kubernetes
+      app.kubernetes.io/component: observer-kubernetes-api
   template:
     metadata:
       labels:
         {{- include "snowplow.labels" . | nindent 8 }}
         {{- include "avalanche.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: observer-kubernetes
+        app.kubernetes.io/component: observer-kubernetes-api
     spec:
-      # Note: observer-kubernetes has its own service account for K8s API access
       serviceAccountName: {{ include "avalanche.fullname" . }}-observer-kubernetes
       imagePullSecrets:
       - name: {{ .Values.dockerconfigjson.name }}
       containers:
-        - name: observer-kubernetes
+        - name: observer-kubernetes-api
           image: {{ include "avalanche.image" (dict "images" .Values.images "image" .Values.observerKubernetes.image) }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           args:
             - observer
             - --config
-            - /configs/observer-kubernetes.yaml
+            - /configs/observer-kubernetes-api.yaml
           env:
             - name: AVALANCHE_LOG_LEVEL
               value: {{ .Values.images.logLevel | quote }}
             - name: AVALANCHE_NATS_URL
               value: "nats://{{ include "avalanche.fullname" . }}-nats:4222"
+            # api observer keeps the unsuffixed componentId for backwards
+            # compatibility with existing test plans (which reference
+            # external-observer-kubernetes.yaml with name=k8s-observer-kubernetes).
             - name: AVALANCHE_COMPONENT_ID
               value: {{ .Values.observerKubernetes.componentId | quote }}
             # Database configuration
@@ -68,7 +73,6 @@ spec:
               readOnly: true
           resources:
             {{- toYaml .Values.observerKubernetes.resources | nindent 12 }}
-          # Liveness probe - check NATS health endpoint (consistent with other components)
           livenessProbe:
             exec:
               command:
@@ -90,4 +94,101 @@ spec:
         - name: config
           configMap:
             name: {{ include "avalanche.fullname" . }}-config
+{{- end }}
+
+{{- if .Values.observerKubernetes.cloudwatch.enabled }}
+---
+# observer-kubernetes (cloudwatch): reads pod-level Container Insights and/or
+# AWS/Kinesis stream metrics via IRSA. Independent from the api observer above
+# — both can run simultaneously, sharing the same SA.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "avalanche.fullname" . }}-observer-kubernetes-cloudwatch
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "snowplow.labels" . | nindent 4 }}
+    app.kubernetes.io/component: observer-kubernetes-cloudwatch
+spec:
+  replicas: {{ .Values.observerKubernetes.replicas }}
+  selector:
+    matchLabels:
+      {{- include "avalanche.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: observer-kubernetes-cloudwatch
+  template:
+    metadata:
+      labels:
+        {{- include "snowplow.labels" . | nindent 8 }}
+        {{- include "avalanche.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: observer-kubernetes-cloudwatch
+    spec:
+      serviceAccountName: {{ include "avalanche.fullname" . }}-observer-kubernetes
+      imagePullSecrets:
+      - name: {{ .Values.dockerconfigjson.name }}
+      containers:
+        - name: observer-kubernetes-cloudwatch
+          image: {{ include "avalanche.image" (dict "images" .Values.images "image" .Values.observerKubernetes.image) }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          args:
+            - observer
+            - --config
+            - /configs/observer-kubernetes-cloudwatch.yaml
+          env:
+            - name: AVALANCHE_LOG_LEVEL
+              value: {{ .Values.images.logLevel | quote }}
+            - name: AVALANCHE_NATS_URL
+              value: "nats://{{ include "avalanche.fullname" . }}-nats:4222"
+            - name: AVALANCHE_COMPONENT_ID
+              value: "{{ .Values.observerKubernetes.componentId }}-cloudwatch"
+            # Database configuration
+            {{- if eq .Values.database.type "influxdb" }}
+            - name: AVALANCHE_DB_TYPE
+              value: "influxdb"
+            - name: AVALANCHE_INFLUXDB_URL
+              value: {{ .Values.database.influxdb.url | quote }}
+            - name: AVALANCHE_INFLUXDB_TOKEN
+              value: {{ .Values.database.influxdb.token | quote }}
+            - name: AVALANCHE_INFLUXDB_ORG
+              value: {{ .Values.database.influxdb.org | quote }}
+            - name: AVALANCHE_INFLUXDB_BUCKET
+              value: {{ .Values.database.influxdb.bucket | quote }}
+            {{- else if eq .Values.database.type "timestream" }}
+            - name: AVALANCHE_DB_TYPE
+              value: "timestream"
+            - name: AVALANCHE_TIMESTREAM_ENABLED
+              value: "true"
+            - name: AVALANCHE_TIMESTREAM_DATABASE
+              value: {{ .Values.database.timestream.database | quote }}
+            - name: AVALANCHE_TIMESTREAM_REGION
+              value: {{ .Values.database.timestream.region | quote }}
+            {{- end }}
+            {{- include "avalanche.awsEnv" . | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /configs
+              readOnly: true
+          resources:
+            {{- toYaml .Values.observerKubernetes.resources | nindent 12 }}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - wget -q --spider http://{{ include "avalanche.fullname" . }}-nats:8222/healthz
+            initialDelaySeconds: 30
+            periodSeconds: 60
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - wget -q --spider http://{{ include "avalanche.fullname" . }}-nats:8222/healthz
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "avalanche.fullname" . }}-config
+{{- end }}
 {{- end }}

--- a/charts/avalanche/templates/observer-kubernetes-rbac.yaml
+++ b/charts/avalanche/templates/observer-kubernetes-rbac.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.observerKubernetes.enabled }}
+# Single ServiceAccount shared by both observer-kubernetes-api and
+# observer-kubernetes-cloudwatch deployments. Carries:
+#  - the ClusterRoleBinding below (when api.enabled) for the K8s API observer
+#  - the IRSA annotation (when cloudwatch.enabled and serviceAccount.iamRoleArn
+#    is set) for the CloudWatch observer
+# Both privileges co-exist harmlessly: a pod that doesn't need one ignores it.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,6 +13,11 @@ metadata:
   labels:
     {{- include "snowplow.labels" . | nindent 4 }}
     app.kubernetes.io/component: observer-kubernetes
+  {{- if and .Values.observerKubernetes.cloudwatch.enabled .Values.observerKubernetes.serviceAccount.iamRoleArn }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.observerKubernetes.serviceAccount.iamRoleArn | quote }}
+  {{- end }}
+{{- if .Values.observerKubernetes.api.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -68,4 +79,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "avalanche.fullname" . }}-observer-kubernetes
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/avalanche/values.yaml
+++ b/charts/avalanche/values.yaml
@@ -9,8 +9,10 @@ global:
   labels: {}
 
 # Deployment mode toggle
-# true (default): Full component configs in ConfigMaps (backward compatible)
-# false: Minimal ConfigMaps (NATS URL + role only), services receive config from controller over NATS
+# true (default): each pod loads its config from disk via --config=/configs/X.yaml
+# false: each pod starts with NATS URL + role only and sets AVALANCHE_MANAGED=true,
+#   then waits for config from the controller over NATS
+# The ConfigMap content is unchanged either way; only the deployment args/env differ.
 legacyMode: true
 
 # Cloud service account configuration (OIDC-based IAM integration)
@@ -524,8 +526,10 @@ observerKubernetes:
     repository: avalanche-observer-private
     tag: kubernetes
   replicas: 1
-  # componentId is suffixed with "-api" or "-cloudwatch" for the two pods so
-  # NATS subjects are unique per observer.
+  # When both observers run, the cloudwatch observer's componentId is suffixed
+  # with "-cloudwatch"; the api observer keeps the base value below (for
+  # backwards compatibility with existing test plans that reference
+  # external-observer-kubernetes.yaml with name=k8s-observer-kubernetes).
   componentId: "k8s-observer-kubernetes"
   config:
     type: "kubernetes"

--- a/charts/avalanche/values.yaml
+++ b/charts/avalanche/values.yaml
@@ -8,6 +8,11 @@ global:
   # Global labels applied to all resources (merged into snowplow.labels)
   labels: {}
 
+# Deployment mode toggle
+# true (default): Full component configs in ConfigMaps (backward compatible)
+# false: Minimal ConfigMaps (NATS URL + role only), services receive config from controller over NATS
+legacyMode: true
+
 # Cloud service account configuration (OIDC-based IAM integration)
 cloudserviceaccount:
   # Whether to create a service-account
@@ -81,12 +86,16 @@ injector:
     type: "http"
     name: "k8s-injector"
     endpoint: "http://host.docker.internal:8085"
-    # Protocol for Snowplow event injector (http or https)
+    # Protocol for HTTP injector type (not used by snowplow type).
     protocol: "http"
     workers: 3
     timeout: "5s"
     # Skip TLS certificate verification (useful for testing with self-signed certs)
     insecureSkipVerify: false
+    # Generator config for snowplow injector type (go-event-generator)
+    # generator:
+    #   preset: "typical-web"
+    #   seed: 0
   resources:
     requests:
       memory: "64Mi"
@@ -112,6 +121,22 @@ observer:
     # For snowplow-kinesis observer type:
     # streamArn: ""  # AWS Kinesis stream ARN
     # region: ""     # AWS region
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "100m"
+    limits:
+      memory: "256Mi"
+      cpu: "500m"
+
+# Mock Target configuration (self-contained testing without external collector)
+mockTarget:
+  enabled: false  # Enable for self-contained testing (no external collector needed)
+  image:
+    repository: avalanche-mock-target-private
+    tag: latest
+  replicas: 1
+  port: 8085
   resources:
     requests:
       memory: "64Mi"
@@ -279,11 +304,15 @@ aggregatorKubernetes:
       phase: "kubernetes_monitoring_phase"
       run: "kubernetes_monitoring_run"
     windowDuration: "30s"
+    # `role` (QA-827 Phase 2) lets the aggregator emit (role × phase) rows
+    # alongside the legacy per-pod rows. CEL rules in Phase 3 reference
+    # those role-tagged aggregates as `<role>.<metric>_<stat>`.
     groupBy:
       - run_id
       - phase_id
       - namespace
       - pod
+      - role
     fields:
       pod_count:
         - last
@@ -299,6 +328,7 @@ aggregatorKubernetes:
         - mean
         - max
         - min
+        - spread
         - p95
       cpu_limit_millicores:
         - last
@@ -306,6 +336,7 @@ aggregatorKubernetes:
         - mean
         - max
         - min
+        - spread
         - p95
       memory_limit_bytes:
         - last
@@ -319,6 +350,100 @@ aggregatorKubernetes:
         - max
       error_event_count:
         - last
+        - max
+      # CloudWatch-mode fields (QA-822). The CW observer writes percent-of-limit
+      # and percent-of-cluster fields; these aren't produced by the api-mode
+      # observer, but adding them to the aggregator's whitelist is harmless
+      # there (missing fields aggregate to zero) and makes both observer
+      # paths feed equivalent (entity × phase) rows.
+      cpu_usage_percent_of_limit:
+        - mean
+        - max
+        - min
+        - spread
+        - p95
+      memory_usage_percent_of_limit:
+        - mean
+        - max
+        - min
+        - spread
+        - p95
+      cpu_usage_percent_of_cluster:
+        - mean
+        - max
+        - sum
+      memory_usage_percent_of_cluster:
+        - mean
+        - max
+        - sum
+      network_tx_bytes:
+        - sum
+        - max
+      container_restarts:
+        - last
+        - max
+        - sum
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "100m"
+    limits:
+      memory: "256Mi"
+      cpu: "500m"
+
+# Kinesis Stream Aggregator configuration (QA-827 Phase 2)
+# Aggregates kinesis_stream_monitoring per-stream rows into (stream × phase)
+# windows for CEL acceptance rules. Mirrors aggregatorKubernetes — separate
+# deployment, separate ConfigMap entry, same code path; only differs in
+# source measurement, group-by tag, and field whitelist.
+aggregatorKinesisStream:
+  enabled: false  # enable when observerKubernetes.cloudwatch is observing a kinesis_stream target
+  image:
+    repository: avalanche-aggregator-private
+    tag: latest
+  replicas: 1
+  componentId: "kinesis-stream-aggregator"
+  config:
+    type: "metrics-aggregator"
+    name: "kinesis-stream-aggregator"
+    sourceMeasurement: "kinesis_stream_monitoring"
+    outputMeasurements:
+      window: "kinesis_stream_monitoring_window"
+      phase: "kinesis_stream_monitoring_phase"
+      run: "kinesis_stream_monitoring_run"
+    windowDuration: "60s"  # CW kinesis is 60s resolution; window matches
+    groupBy:
+      - run_id
+      - phase_id
+      - region
+      - stream_name
+    fields:
+      incoming_bytes:
+        - sum
+        - max
+      incoming_records:
+        - sum
+        - max
+      outgoing_bytes:
+        - sum
+        - max
+      outgoing_records:
+        - sum
+        - max
+      put_records_latency_ms:
+        - mean
+        - max
+        - min
+        - spread
+        - p95
+      iterator_age_ms_max:
+        - max
+        - mean
+      write_provisioned_throughput_exceeded:
+        - sum
+        - max
+      read_provisioned_throughput_exceeded:
+        - sum
         - max
   resources:
     requests:
@@ -355,30 +480,83 @@ aws:
   # Local only: AWS session token (optional, for temporary credentials)
   sessionToken: ""
 
-# Kubernetes Infrastructure Observer configuration (Phase 12.1)
+# Kubernetes Infrastructure Observer configuration (Phase 12.1 + QA-822)
 observerKubernetes:
-  enabled: false  # Disabled by default - enable when monitoring K8s infrastructure
+  enabled: false  # master toggle — disabled by default; enable to monitor infra
+  # api and cloudwatch are independent observers that can be enabled together
+  # or separately. The previous `mode: api|cloudwatch` toggle has been removed
+  # in favour of these sub-toggles so a deployment can collect native K8s
+  # metrics AND AWS CloudWatch metrics (e.g. Kinesis stream observation)
+  # concurrently — useful when you have K8s API access and want both.
+  api:
+    # Native Kubernetes API observer: reads pod / deployment / event / resource
+    # metrics from the in-cluster K8s API + metrics-server. Requires the
+    # ClusterRole defined in observer-kubernetes-rbac.yaml.
+    enabled: true
+  cloudwatch:
+    # CloudWatch observer (QA-824 + QA-828): reads pod-level Container Insights
+    # metrics and/or AWS/Kinesis stream metrics via IRSA. See targets[].kind for
+    # which AWS namespace each target observes.
+    enabled: false
+    pollInterval: "60s"  # CloudWatch resolution floor is 60s
+    targets: []
+    # Default pod-name → role mapping applied to every container_insights target
+    # that doesn't override it. Strips the snowman / avalanche-test per-run
+    # prefix-and-hash, leaving the deployment-name suffix as the role tag value.
+    # Empty pattern disables the regex layer (RoleResolver still tries known
+    # avalanche components via simplifyPodName).
+    podNamePattern: "^svc-qa-[a-z0-9]+-(.+)$"
+    podNameReplacement: "$1"
+    # Example target shapes:
+    # - kind: container_insights        # default if omitted
+    #   region: "eu-central-1"
+    #   clusterName: "sp-com-snplow-qa-aws-prod1-eks-cluster"
+    #   namespace: "default"
+    #   podNameInclude: ""           # optional Go regex; empty = match all
+    #   podNameExclude: "^observer-" # optional Go regex; defaults to ^observer-
+    #   podNamePattern: "^svc-qa-[a-z0-9]+-(.+)$"   # optional override of the
+    #   podNameReplacement: "$1"                    #   defaults above (regex
+    #                                               #   for stable role tag)
+    # - kind: kinesis_stream
+    #   region: "eu-central-1"
+    #   streamName: "kns-com-snplow-qa-aws-qa-...-raw"
   image:
     repository: avalanche-observer-private
     tag: kubernetes
   replicas: 1
+  # componentId is suffixed with "-api" or "-cloudwatch" for the two pods so
+  # NATS subjects are unique per observer.
   componentId: "k8s-observer-kubernetes"
   config:
     type: "kubernetes"
     name: "k8s-observer-kubernetes"
-    # Scope configuration
+    # Scope configuration (api-mode only)
     namespace: ""  # Empty string means cluster-wide (requires ClusterRole)
     namespaces: []  # List of specific namespaces to monitor
     labelSelector: ""  # Kubernetes label selector (e.g., "app=snowplow")
     fieldSelector: ""  # Kubernetes field selector
     # Polling configuration
     pollInterval: "10s"
-    # Metrics to collect
+    # podNamePattern / podNameReplacement: regex fallback used by RoleResolver
+    # when neither `app.kubernetes.io/name` nor `app` labels are set on the
+    # pod. Defaults match the snowman / avalanche-test naming convention so
+    # the per-run hash is stripped to leave the deployment-name as the role.
+    # Set podNamePattern to "" to skip the regex layer entirely.
+    podNamePattern: "^svc-qa-[a-z0-9]+-(.+)$"
+    podNameReplacement: "$1"
+    # Metrics to collect (api-mode only)
     metrics:
       pods: true
       deployments: true
       events: true
       resources: true  # Requires metrics-server
+  serviceAccount:
+    # IRSA role ARN annotated on the shared ServiceAccount when
+    # cloudwatch.enabled is true. Required in that case; ignored otherwise.
+    # The same SA is bound to the api-mode ClusterRole when api.enabled, so
+    # both observer pods (when both are deployed) share one SA with both
+    # IRSA + ClusterRole privileges available.
+    iamRoleArn: ""
   resources:
     requests:
       memory: "64Mi"


### PR DESCRIPTION
## Summary

Syncs the avalanche `QA-822` branch's `helm/` tree into `charts/avalanche/`, bumping the chart from `0.2.0` → `0.5.0`. The avalanche repo is source-of-truth for the chart; this PR publishes the cumulative result here.

## What changes for chart consumers

**New deployments** (gated by their feature toggles)
- `aggregator-kinesis-stream` — per-stream Kinesis aggregator
- `mock-target` (+ service) — in-cluster collector stand-in for self-contained tests
- `observer-kubernetes` split into `observer-kubernetes-api` + `observer-kubernetes-cloudwatch`, sharing one ServiceAccount with optional IRSA annotation

**New top-level values keys**: `aggregatorKinesisStream`, `mockTarget`, `legacyMode`

**Existing values extended**
- `observerKubernetes.cloudwatch.targets[]` gains `kind`, `podNamePattern`, `podNameReplacement`
- `observerKubernetes.config` gains `podNamePattern`, `podNameReplacement`
- `aggregatorKubernetes.config.groupBy` adds `role`; field whitelist extended with the six CW-mode fields (`cpu_usage_percent_of_limit`, `memory_usage_percent_of_limit`, `cpu_usage_percent_of_cluster`, `memory_usage_percent_of_cluster`, `network_tx_bytes`, `container_restarts`); `spread` aggregation added

**⚠️ BREAKING — values-schema migration required**

`observerKubernetes.mode: api|cloudwatch` is removed. Replace with the independent sub-toggles:

```yaml
# before
observerKubernetes:
  mode: cloudwatch

# after
observerKubernetes:
  api:
    enabled: false       # default: true
  cloudwatch:
    enabled: true        # default: false
```

Both can run side-by-side when both are `true`.

## Testing

The chart has been tested end-to-end on the QA sandbox EKS cluster (`sp-qa-sandbox-eks`) via the snowman performance test runner. Multiple successful runs across QA-822 Phases 1, 2, and 3 with both observer paths enabled (api + cloudwatch), 1-replica and 2-replica correlator configurations, and the kinesis-stream aggregator targeting a real stream. All 16+ existing CEL acceptance rules pass; new role-scoped + Kinesis rules pass; adjudicator `result=passed`.

## Test plan

- [ ] `helm lint charts/avalanche/` passes (verified locally — 0 charts failed)
- [ ] `helm template charts/avalanche/` renders without errors (verified locally during Phase 1-3 development)
- [ ] CI chart-testing job green
- [ ] Reviewer confirms BREAKING change is correctly flagged in CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)