### PR TITLE
Hardened security context configuration for pods in Helm charts (closes #333)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+Version 0.3.36 (2026-05-14)
+---------------------------
+charts/service-deployment-0.41.0: Add containerSecurityContext with kubesec.io hardened defaults; add extraVolumes, extraVolumeMounts and config.workingDir
+charts/cron-job-0.15.0: Add containerSecurityContext with kubesec.io hardened defaults; add extraVolumes, extraVolumeMounts and config.workingDir
+charts/snowplow-iglu-server-0.18.0: Add containerSecurityContext with kubesec.io hardened defaults; add service.extraVolumes and service.extraVolumeMounts
+
 Version 0.3.35 (2026-05-07)
 ---------------------------
 charts/multi-service-deployment-0.8.0: Add rate limiting middleware support via common dependency bump (closes #328)

--- a/charts/cron-job/Chart.yaml
+++ b/charts/cron-job/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cron-job
 description: A Helm Chart to deploy an arbitrary container as a cron job.
-version: 0.14.0
+version: 0.15.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/cron-job/README.md
+++ b/charts/cron-job/README.md
@@ -1,73 +1,67 @@
 # cron-job
 
-A helm chart to configure a cron job.
+![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square)
 
-## TL;DR
+A Helm Chart to deploy an arbitrary container as a cron job.
 
-```bash
-helm repo add snowplow-devops https://snowplow-devops.github.io/helm-charts
-helm install cron-job snowplow-devops/cron-job
-```
+**Homepage:** <https://github.com/snowplow-devops/helm-charts>
 
-## Introduction
+## Maintainers
 
-This chart creates a cron job of an arbitrary input container and input variables configured on the environment.
+| Name | Email | Url |
+| ---- | ------ | --- |
+| jbeemster | <jbeemster@users.noreply.github.com> | <https://github.com/jbeemster> |
 
-## Installing the Chart
+## Source Code
 
-Install or upgrading the chart with default configuration:
+* <https://github.com/snowplow-devops/helm-charts>
 
-```bash
-helm upgrade --install cron-job snowplow-devops/cron-job
-```
+## Requirements
 
-_Note_: As default the chart simply deploys an example busybox to illustrate running a simple command - take note of the default `values.yaml` and alter to suit your needs!
+| Repository | Name | Version |
+|------------|------|---------|
+| https://snowplow-devops.github.io/helm-charts | cloudserviceaccount | 0.3.0 |
+| https://snowplow-devops.github.io/helm-charts | dockerconfigjson | 0.1.0 |
 
-To see example input you should also dig through the `values.yaml` to understand the full range of options available.
-
-## Uninstalling the Chart
-
-To uninstall/delete the `cron-job` release:
-
-```bash
-helm delete cron-job
-```
-
-## Configuration
+## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.cloud | string | `""` | Cloud specific bindings (options: aws, gcp, azure) |
-| global.labels | object | `{}` | Global labels deployed to all resources deployed by the chart |
-| fullnameOverride | string | `""` | Overrides the full-name given to the deployment resources (default: .Release.Name) |
-| schedules | list | `[]` | List of cron schedules. Each schedule must have unique `name`, `crontab`, and optional `suspend` and `env` fields |
-| schedules[].env | object | `{}` | Schedule-specific environment variables that extend/override global config.env |
-| concurrencyPolicy | string | `"Forbid"` |  |
-| restartPolicy | string | `"Never"` |  |
-| failedJobsHistoryLimit | int | `1` |  |
-| successfulJobsHistoryLimit | int | `1` |  |
-| ttlSecondsAfterFinished | int | `nil` | TTL (in seconds) for cleaning up finished jobs (both failed and successful) |
 | backoffLimit | int | `6` | The number of retries to attempt before marking the job as failed |
-| activeDeadlineSeconds | int | `nil` | The number of seconds the job is allowed to run before being terminated (optional) |
-| image.repository | string | `"busybox"` |  |
-| image.tag | string | `"latest"` |  |
-| image.isRepositoryPublic | bool | `true` | Whether the repository is public |
-| image.pullPolicy | string | `"IfNotPresent"` | The image pullPolicy to use |
-| config.command | list | `[]` |  |
+| cloudserviceaccount.aws.roleARN | string | `""` | IAM Role ARN to bind to the k8s service account |
+| cloudserviceaccount.azure.managedIdentityId | string | `""` | Workload managed identity id to bind to the k8s service account |
+| cloudserviceaccount.deploy | bool | `false` | Whether to create a service-account |
+| cloudserviceaccount.gcp.serviceAccount | string | `""` | Service Account email to bind to the k8s service account |
+| cloudserviceaccount.name | string | `"snowplow-cron-job-service-account"` | Name of the service-account to create |
+| concurrencyPolicy | string | `"Forbid"` |  |
 | config.args | list | `[]` |  |
+| config.command | list | `[]` |  |
 | config.env | object | `{}` | Map of environment variables to use within the job |
 | config.secrets | object | `{}` | Map of secrets that will be exposed as environment variables within the job |
+| config.workingDir | string | `""` | Optional working directory for the container process. Useful when readOnlyRootFilesystem is true and the job writes to its CWD; point at a writable mount declared via extraVolumes / extraVolumeMounts. |
 | configMaps | list | `[]` | List of config maps to mount to the deployment |
-| resources | object | `{}` | Map of resource constraints for the deployment |
+| containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":false,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context configuration These defaults follow kubesec.io best practices for hardened deployments.  runAsUser / runAsGroup are intentionally not pinned. Different container images bake in different non-root USER directives, and forcing a specific UID can prevent the image's user from accessing its own files. The image's USER directive selects the runtime UID; runAsNonRoot: true still enforces the non-root invariant. Override per-deployment if you need a specific UID.  readOnlyRootFilesystem defaults to false so existing deployments are not broken on upgrade; set it to true per-deployment once writable paths (e.g. /tmp) are mounted as emptyDirs. |
+| customRole.definition | list | `[]` | Array of role definitions to setup for the custom role |
+| customRole.deploy | bool | `false` | Whether to deploy the custom role and bind it to the cloudserviceaccount |
+| dockerconfigjson.email | string | `""` | Email address for user of the private repository |
 | dockerconfigjson.name | string | `"snowplow-cron-job-dockerhub"` | Name of the secret to use for the private repository |
-| dockerconfigjson.username | string | `""` | Username for the private repository |
 | dockerconfigjson.password | string | `""` | Password for the private repository |
 | dockerconfigjson.server | string | `"https://index.docker.io/v1/"` | Repository server URL |
-| dockerconfigjson.email | string | `""` | Email address for user of the private repository |
-| cloudserviceaccount.deploy | bool | `false` | Whether to create a service-account |
-| cloudserviceaccount.name | string | `"snowplow-cron-job-service-account"` | Name of the service-account to create |
-| cloudserviceaccount.aws.roleARN | string | `""` | IAM Role ARN to bind to the k8s service account |
-| cloudserviceaccount.gcp.serviceAccount | string | `""` | Service Account email to bind to the k8s service account |
-| cloudserviceaccount.azure.managedIdentityId | string | `""` | Workload managed identity id to bind to the k8s service account |
-| customRole.deploy | bool | `false` | Whether to deploy the custom role and bind it to the cloudserviceaccount |
-| customRole.definition | list | `[]` | Array of role definitions to setup for the custom role |
+| dockerconfigjson.username | string | `""` | Username for the private repository |
+| extraVolumeMounts | list | `[]` | Additional volume mounts to attach to the container. Pair with extraVolumes above. |
+| extraVolumes | list | `[]` | Additional volumes to attach to the pod spec. Useful with readOnlyRootFilesystem: true — declare writable scratch space (e.g. emptyDir on /tmp) without disabling the hardened default. |
+| failedJobsHistoryLimit | int | `1` |  |
+| fullnameOverride | string | `""` | Overrides the full-name given to the deployment resources (default: .Release.Name) |
+| global.cloud | string | `""` | Cloud specific bindings (options: aws, gcp, azure) |
+| global.labels | object | `{}` | Global labels deployed to all resources deployed by the chart |
+| image.isRepositoryPublic | bool | `true` | Whether the repository is public |
+| image.pullPolicy | string | `"IfNotPresent"` | The image pullPolicy to use |
+| image.repository | string | `"busybox"` |  |
+| image.tag | string | `"latest"` |  |
+| resources | object | `{}` | Map of resource constraints for the deployment |
+| restartPolicy | string | `"Never"` |  |
+| schedules | list | `[]` |  |
+| successfulJobsHistoryLimit | int | `1` |  |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/cron-job/templates/deployment.yaml
+++ b/charts/cron-job/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
 
           restartPolicy: "{{ $.Values.restartPolicy }}"
 
-          {{- if $.Values.configMaps }}
+          {{- if or $.Values.configMaps $.Values.extraVolumes }}
           volumes:
           {{- range $v := $.Values.configMaps }}
           - configMap:
@@ -53,12 +53,22 @@ spec:
               optional: false
             name: {{ $v.name }}
           {{- end }}
+          {{- with $.Values.extraVolumes }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           {{- end }}
 
           containers:
           - name: "{{ include "app.fullname" $ }}-{{ $s.name }}"
             image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
             imagePullPolicy: {{ default "IfNotPresent" $.Values.image.pullPolicy }}
+
+            securityContext:
+              {{- toYaml $.Values.containerSecurityContext | nindent 14 }}
+
+            {{- if $.Values.config.workingDir }}
+            workingDir: {{ $.Values.config.workingDir | quote }}
+            {{- end }}
 
             {{- if $.Values.config.command  }}
             command:
@@ -92,7 +102,7 @@ spec:
             resources:
               {{- toYaml $.Values.resources | nindent 14 }}
 
-            {{- if $.Values.configMaps }}
+            {{- if or $.Values.configMaps $.Values.extraVolumeMounts }}
             volumeMounts:
             {{- range $v := $.Values.configMaps }}
             - mountPath: "{{ $v.mountPath }}"
@@ -102,6 +112,9 @@ spec:
               mountPropagation: None
               {{- end }}
               name: {{ $v.name }}
+            {{- end }}
+            {{- with $.Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- end }}
 {{- end }}

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -40,6 +40,11 @@ config:
   #  - "-c"
   #  - "echo 'Environment $(hello_env)! Secret $(username).'"
 
+  # -- Optional working directory for the container process.
+  # Useful when readOnlyRootFilesystem is true and the job writes to its CWD;
+  # point at a writable mount declared via extraVolumes / extraVolumeMounts.
+  workingDir: ""
+
   # -- Map of environment variables to use within the job
   env: {}
   #  hello_env: "world"
@@ -66,6 +71,41 @@ resources: {}
 #  requests:
 #    cpu: 400m
 #    memory: 512Mi
+
+# -- Container security context configuration
+# These defaults follow kubesec.io best practices for hardened deployments.
+#
+# runAsUser / runAsGroup are intentionally not pinned. Different container
+# images bake in different non-root USER directives, and forcing a specific
+# UID can prevent the image's user from accessing its own files. The image's
+# USER directive selects the runtime UID; runAsNonRoot: true still enforces
+# the non-root invariant. Override per-deployment if you need a specific UID.
+#
+# readOnlyRootFilesystem defaults to false so existing deployments are not
+# broken on upgrade; set it to true per-deployment once writable paths
+# (e.g. /tmp) are mounted as emptyDirs.
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Additional volumes to attach to the pod spec.
+# Useful with readOnlyRootFilesystem: true — declare writable scratch space
+# (e.g. emptyDir on /tmp) without disabling the hardened default.
+extraVolumes: []
+#  - name: tmp
+#    emptyDir: {}
+
+# -- Additional volume mounts to attach to the container.
+# Pair with extraVolumes above.
+extraVolumeMounts: []
+#  - name: tmp
+#    mountPath: /tmp
 
 dockerconfigjson:
   # -- Name of the secret to use for the private repository

--- a/charts/service-deployment/Chart.yaml
+++ b/charts/service-deployment/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: service-deployment
 description: A Helm Chart to setup a generic deployment with optional service/hpa/vpa bindings
-version: 0.40.0
+version: 0.41.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/service-deployment/README.md
+++ b/charts/service-deployment/README.md
@@ -112,8 +112,8 @@ helm delete service-deployment
 | vpa.enabled | bool | `false` | Whether to deploy VPA rules |
 | vpa.spec | object | `{}` | VPA resource specification (accepts any valid VPA spec fields) |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pullPolicy to use |
-| image.repository | string | `"nginx"` |  |
-| image.tag | string | `"latest"` |  |
+| image.repository | string | `"nginxinc/nginx-unprivileged"` |  |
+| image.tag | string | `"stable"` |  |
 | livenessProbe | object | `{"exec":{"command":[]},"failureThreshold":3,"httpGet":{"path":"","port":""},"initialDelaySeconds":5,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":5}` | livenessProbe is enabled if httpGet.path or exec.command are present |
 | livenessProbe.exec.command | list | `[]` | Command/arguments to execute to determine liveness |
 | livenessProbe.httpGet.path | string | `""` | Path for health checks to be performed to determine liveness |

--- a/charts/service-deployment/README.md
+++ b/charts/service-deployment/README.md
@@ -1,75 +1,29 @@
 # service-deployment
 
-A helm chart to deploy a generic deployment with optional service bindings.
+![Version: 0.41.0](https://img.shields.io/badge/Version-0.41.0-informational?style=flat-square)
 
-## TL;DR
+A Helm Chart to setup a generic deployment with optional service/hpa/vpa bindings
 
-```bash
-helm repo add snowplow-devops https://snowplow-devops.github.io/helm-charts
-helm install service-deployment snowplow-devops/service-deployment
-```
+**Homepage:** <https://github.com/snowplow-devops/helm-charts>
 
-## Introduction
+## Maintainers
 
-This chart attempts to take care of all the most common requirements of launching a long-running service that requires auto-scaling:
+| Name | Email | Url |
+| ---- | ------ | --- |
+| jbeemster | <jbeemster@users.noreply.github.com> | <https://github.com/jbeemster> |
 
-- Downloading from private Docker repositories
-- Auto-scaling pods based on CPU usage
-- Mounting config volumes
-- Configuring secrets
-- Binding service-accounts with cloud specific IAM policies
-- Setting up persistent-volumes and binding them
+## Source Code
 
-_Note_: This should be a long running process - if you are looking for cron-based execution see our `cron-job` chart.
+* <https://github.com/snowplow-devops/helm-charts>
 
-This chart won't solve for every possible option of deploying a service - it is meant to serve as an opinionated starting point to get something working decently well.  For more flexibility open a PR or fork this chart to suit your specific needs.
+## Requirements
 
-### VPA RBAC Requirements
+| Repository | Name | Version |
+|------------|------|---------|
+| https://snowplow-devops.github.io/helm-charts | cloudserviceaccount | 0.3.0 |
+| https://snowplow-devops.github.io/helm-charts | dockerconfigjson | 0.1.0 |
 
-If you enable VPA (`vpa.enabled: true`), you may need to ensure that the appropriate RBAC permissions are in place for the service account to manage VPA resources. This typically requires a ClusterRole with permissions to manage `verticalpodautoscalers` resources in the `autoscaling.k8s.io` API group, bound to your service account via a ClusterRoleBinding.
-
-Example RBAC configuration:
-```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: vpa-manager
-rules:
-- apiGroups: ["autoscaling.k8s.io"]
-  resources: ["verticalpodautoscalers"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: vpa-manager-binding
-subjects:
-- kind: ServiceAccount
-  name: your-service-account-name
-  namespace: your-namespace
-roleRef:
-  kind: ClusterRole
-  name: vpa-manager
-  apiGroup: rbac.authorization.k8s.io
-```
-
-## Installing the Chart
-
-Install or upgrading the chart with default configuration:
-
-```bash
-helm upgrade --install service-deployment snowplow-devops/service-deployment
-```
-
-## Uninstalling the Chart
-
-To uninstall/delete the `service-deployment` release:
-
-```bash
-helm delete service-deployment
-```
-
-## Configuration
+## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -84,11 +38,14 @@ helm delete service-deployment
 | config.env | string | `nil` | Map of environment variables to use within the job |
 | config.secrets | object | `{}` | Map of secrets that will be exposed as environment variables within the job |
 | config.secretsB64 | object | `{}` | Map of base64-encoded secrets that will be exposed as environment variables within the job |
-| config.sharedNamespaceConfigMaps | list | `[]` | List of config maps from same namespace to reference and mount in the deployment |
+| config.sharedNamespaceConfigMaps | list | `[]` | List of configMaps from other deployments within the    same namespace - to reference and mount in the deployment |
+| config.workingDir | string | `""` | Optional working directory for the container process. Useful when readOnlyRootFilesystem is true and the app writes to its CWD; point at a writable mount declared via extraVolumes / extraVolumeMounts. |
 | configMaps | list | `[]` | List of config maps to mount to the deployment |
+| containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":false,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context configuration These defaults follow kubesec.io best practices for hardened deployments.  runAsUser / runAsGroup are intentionally not pinned. Different container images bake in different non-root USER directives, and forcing a specific UID can prevent the image's user from accessing its own files. The image's USER directive selects the runtime UID; runAsNonRoot: true still enforces the non-root invariant. Override per-deployment if you need a specific UID.  readOnlyRootFilesystem defaults to false so existing deployments are not broken on upgrade; set it to true per-deployment once writable paths (e.g. /tmp) are mounted as emptyDirs. |
 | deployment.kind | string | `"Deployment"` | Can be either a "Deployment" or "StatefulSet" |
 | deployment.podAnnotations | object | `{}` | Map of annotations that will be added to each pod in the deployment |
 | deployment.podLabels | object | `{}` | Map of labels that will be added to each pod in the deployment |
+| deployment.replicas | int | `1` |  |
 | deployment.scaleToZero | bool | `false` | When enabled, disables the HPA and scales the deployment to zero replicas |
 | deployment.strategy | object | `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"}` | How to replace existing pods with new ones |
 | deployment.strategy.rollingUpdate.maxSurge | string | `"25%"` | The maximum number or precent of pods that can be created in addition to the current number of pods during the rolling update. Can be set as number "5" for 5 additional pods |
@@ -99,18 +56,18 @@ helm delete service-deployment
 | dockerconfigjson.password | string | `""` | Password for the private repository |
 | dockerconfigjson.server | string | `"https://index.docker.io/v1/"` | Repository server URL |
 | dockerconfigjson.username | string | `""` | Username for the private repository |
-| extraObjects | list | `[]` | Extra Kubernetes objects to deploy alongside the service |
+| extraObjects | list | `[]` | Extra Kubernetes objects to deploy alongside the service This allows for additional resources like Middleware, NetworkPolicy, etc. |
+| extraVolumeMounts | list | `[]` | Additional volume mounts to attach to the container. Pair with extraVolumes above. |
+| extraVolumes | list | `[]` | Additional volumes to attach to the pod spec. Useful with readOnlyRootFilesystem: true — declare writable scratch space (e.g. emptyDir on /tmp) without disabling the hardened default. |
 | fullnameOverride | string | `""` | Overrides the full-name given to the deployment resources (default: .Release.Name) |
 | global.cloud | string | `""` | Cloud specific bindings (options: aws, gcp , azure) |
-| global.labels | object | `{}` | Global labels deployed to all resources deployed by the chart |
-| hooks | object | `{}` | Optional pre/post install/upgrade hooks. Each hook can be configured with image, script, secrets, configFiles, etc. |
-| hpa.metrics | object | `[{"type":"Resource","resource":{"name":"cpu","target":{"type":"Utilization","averageUtilization":75}}}]` | Metrics for HPA configuration |
+| global.labels | object | `{}` |  |
+| hooks | object | `{}` |  |
 | hpa.behavior | object | `{}` |  |
 | hpa.deploy | bool | `true` | Whether to deploy HPA rules |
 | hpa.maxReplicas | int | `20` | Maximum number of pods to deploy |
+| hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":75,"type":"Utilization"}},"type":"Resource"}]` | Default average CPU utilization before auto-scaling starts |
 | hpa.minReplicas | int | `1` | Minimum number of pods to deploy |
-| vpa.enabled | bool | `false` | Whether to deploy VPA rules |
-| vpa.spec | object | `{}` | VPA resource specification (accepts any valid VPA spec fields) |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pullPolicy to use |
 | image.repository | string | `"nginxinc/nginx-unprivileged"` |  |
 | image.tag | string | `"stable"` |  |
@@ -127,34 +84,44 @@ helm delete service-deployment
 | persistentVolume.statefulSetRetentionPolicy.whenDeleted | string | `"Retain"` | What to do with volumes when the StatefulSet is deleted |
 | persistentVolume.statefulSetRetentionPolicy.whenScaled | string | `"Delete"` | What to do with volumes when scaling occurs |
 | persistentVolume.subPath | string | `""` | Subdirectory of Persistent Volume to mount |
+| podDisruptionBudget.enabled | bool | `false` | Whether to deploy a PodDisruptionBudget |
+| podDisruptionBudget.minAvailable | int | `1` | Minimum number (or percentage) of pods that must remain available. Mutually exclusive with maxUnavailable. |
 | priorityClassName | string | `""` | PriorityClassName for pods |
 | readinessProbe | object | `{"exec":{"command":[]},"failureThreshold":3,"httpGet":{"path":""},"initialDelaySeconds":5,"periodSeconds":5,"successThreshold":2,"timeoutSeconds":5}` | readinessProbe is enabled if httpGet.path or exec.command are present |
 | readinessProbe.exec.command | list | `[]` | Command/arguments to execute to determine readiness |
 | readinessProbe.httpGet.path | string | `""` | Path for health checks to be performed to determine readiness |
-| replicas | int | `1` | Number of replicas to deploy when HPA is disabled (`hpa.deploy: false`) |
 | resources | object | `{}` | Map of resource constraints for the service |
 | securityContext | object | `{}` | Pod security context configuration This is particularly useful when using persistent volumes with non-root container users Setting fsGroup ensures that mounted volumes have the correct group ownership |
+| service.additionalPorts | list | `[]` | Additional ports to expose on the Kubernetes Service |
 | service.annotations | object | `{}` | Map of annotations to add to the service |
 | service.aws.targetGroupARN | string | `""` | EC2 TargetGroup ARN to bind the service onto |
+| service.basicAuth | object | `{"enabled":false,"users":""}` | Basic authentication configuration |
+| service.basicAuth.enabled | bool | `false` | Enable basic authentication |
+| service.basicAuth.users | string | `""` | htpasswd-formatted users string (bcrypt hash, e.g. "user:$2y$05$...") |
 | service.deploy | bool | `true` | Whether to setup service bindings (note: only NodePort is supported) |
 | service.gcp.networkEndpointGroupName | string | `""` | Name of the Network Endpoint Group to bind onto |
 | service.ingress | object | `{}` | A map of ingress rules to deploy |
-| service.ingressIPAllowlist | list | `[]` | List of IP addresses/CIDRs to restrict ingress traffic to |
-| service.additionalPorts | list | `[]` | Additional ports to expose on the Kubernetes Service (e.g. `[{name: "gossip", port: 7946, targetPort: 7946, protocol: "TCP"}]`) |
+| service.ingressIPAllowlist | list | `[]` | List of IP addresses to restrict ingress traffic to |
 | service.port | int | `8000` | Port to bind and expose the service on |
 | service.protocol | string | `"TCP"` | Protocol that the service leverages (note: TCP or UDP) |
-| service.rateLimit.average | int | `100` | Average number of requests per period allowed |
-| service.rateLimit.burst | int | `200` | Maximum number of requests allowed in a burst |
+| service.rateLimit | object | `{"average":100,"burst":200,"enabled":false,"period":"1m","sourceCriterion":{"enabled":false,"ipStrategy":{"depth":1,"excludedIPs":[]},"requestHeaderName":"","type":"ipStrategy"}}` | Rate limiting configuration WARNING: These defaults are conservative and intended for testing. For production use, adjust based on your service's expected traffic patterns. Current defaults: 100 requests per minute = ~4.3M requests/month per IP (or total if global) |
+| service.rateLimit.average | int | `100` | Average number of requests per period |
+| service.rateLimit.burst | int | `200` | Burst size - maximum number of requests allowed in a burst |
 | service.rateLimit.enabled | bool | `false` | Enable rate limiting |
 | service.rateLimit.period | string | `"1m"` | Time period for rate limiting (e.g., "1m", "1s", "1h") |
+| service.rateLimit.sourceCriterion | object | `{"enabled":false,"ipStrategy":{"depth":1,"excludedIPs":[]},"requestHeaderName":"","type":"ipStrategy"}` | Source-based rate limiting configuration |
 | service.rateLimit.sourceCriterion.enabled | bool | `false` | Enable source-based rate limiting (false = global rate limit for entire service) |
+| service.rateLimit.sourceCriterion.ipStrategy | object | `{"depth":1,"excludedIPs":[]}` | Configuration for IP-based rate limiting (when type is "ipStrategy") |
 | service.rateLimit.sourceCriterion.ipStrategy.depth | int | `1` | Depth of IP extraction for X-Forwarded-For header (1 = direct, 2 = behind 1 proxy) |
 | service.rateLimit.sourceCriterion.ipStrategy.excludedIPs | list | `[]` | List of IPs/CIDRs that bypass rate limiting entirely (e.g., internal networks, monitoring) |
 | service.rateLimit.sourceCriterion.requestHeaderName | string | `""` | Header name to use for rate limiting (required when type is "requestHeaderName") |
 | service.rateLimit.sourceCriterion.type | string | `"ipStrategy"` | Type of source criterion: "ipStrategy" (default), "requestHeaderName", or "requestHost" |
-| service.basicAuth.enabled | bool | `false` | Enable basic authentication |
-| service.basicAuth.users | string | `""` | htpasswd-formatted users string (bcrypt hash, e.g. "user:$2y$05$...") |
 | service.targetPort | int | `80` | The Target Port that the actual application is being exposed on |
 | terminationGracePeriodSeconds | int | `60` | Grace period for termination of the service |
-| tolerations | list |`[]` | Tolerations labels for pod assignment with matching taints |
-| topologySpreadConstraints | object | `{}` | Topology Spread Constraints for pod assignment |
+| tolerations | list | `[]` | Allow the scheduler to schedule pods with matching taints  more details here: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
+| topologySpreadConstraints | object | `{}` | topologySpreadConstraints control how Pods are  spread across your cluster among failure-domains such as regions, zones, nodes, and other user-defined topology domains.  more details here: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/ |
+| vpa.enabled | bool | `false` | Whether to deploy VPA rules |
+| vpa.spec | object | `{}` | VPA resource specification (accepts any valid VPA spec fields) |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/service-deployment/templates/deployment.yaml
+++ b/charts/service-deployment/templates/deployment.yaml
@@ -77,6 +77,9 @@ spec:
         persistentVolumeClaim:
           claimName: {{ include "app.fullname" . }}
       {{- end }}
+      {{- with .Values.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
 
       {{- if .Values.affinity }}
       affinity:
@@ -96,6 +99,13 @@ spec:
       - name: "{{ include "app.fullname" . }}"
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
+
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 10 }}
+
+        {{- if .Values.config.workingDir }}
+        workingDir: {{ .Values.config.workingDir | quote }}
+        {{- end }}
 
         {{- if .Values.config.command }}
         command:
@@ -197,6 +207,9 @@ spec:
         - name: {{ include "app.fullname" . }}
           mountPath: {{ .Values.persistentVolume.mountPath }}
           subPath: "{{ .Values.persistentVolume.subPath }}"
+        {{- end }}
+        {{- with .Values.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
   {{- if and (.Values.persistentVolume.enabled) (eq .Values.deployment.kind "StatefulSet") }}
   persistentVolumeClaimRetentionPolicy:

--- a/charts/service-deployment/values.yaml
+++ b/charts/service-deployment/values.yaml
@@ -9,8 +9,8 @@ global:
 fullnameOverride: ""
 
 image:
-  repository: "nginx"
-  tag: "latest"
+  repository: "nginxinc/nginx-unprivileged"
+  tag: "stable"
   # -- The image pullPolicy to use
   pullPolicy: "IfNotPresent"
 

--- a/charts/service-deployment/values.yaml
+++ b/charts/service-deployment/values.yaml
@@ -21,6 +21,11 @@ config:
   #  - "-c"
   #  - "echo 'Environment $(hello_env)! Secret $(username).'"
 
+  # -- Optional working directory for the container process.
+  # Useful when readOnlyRootFilesystem is true and the app writes to its CWD;
+  # point at a writable mount declared via extraVolumes / extraVolumeMounts.
+  workingDir: ""
+
   # -- Map of environment variables to use within the job
   env:
   #  hello_env: "world"
@@ -362,6 +367,41 @@ persistentVolume:
 securityContext: {}
   # -- Set the fsGroup for all containers in the pod. This ensures mounted volumes are accessible to non-root users
   # fsGroup: 1000
+
+# -- Container security context configuration
+# These defaults follow kubesec.io best practices for hardened deployments.
+#
+# runAsUser / runAsGroup are intentionally not pinned. Different container
+# images bake in different non-root USER directives, and forcing a specific
+# UID can prevent the image's user from accessing its own files. The image's
+# USER directive selects the runtime UID; runAsNonRoot: true still enforces
+# the non-root invariant. Override per-deployment if you need a specific UID.
+#
+# readOnlyRootFilesystem defaults to false so existing deployments are not
+# broken on upgrade; set it to true per-deployment once writable paths
+# (e.g. /tmp) are mounted as emptyDirs.
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Additional volumes to attach to the pod spec.
+# Useful with readOnlyRootFilesystem: true — declare writable scratch space
+# (e.g. emptyDir on /tmp) without disabling the hardened default.
+extraVolumes: []
+#  - name: tmp
+#    emptyDir: {}
+
+# -- Additional volume mounts to attach to the container.
+# Pair with extraVolumes above.
+extraVolumeMounts: []
+#  - name: tmp
+#    mountPath: /tmp
 
 # Hooks Configuration
 hooks:

--- a/charts/snowplow-iglu-server/Chart.yaml
+++ b/charts/snowplow-iglu-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: snowplow-iglu-server
 description: A Helm Chart to deploy the Snowplow Iglu Server project
-version: 0.17.0
+version: 0.18.0
 appVersion: "0.13.0"
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts

--- a/charts/snowplow-iglu-server/README.md
+++ b/charts/snowplow-iglu-server/README.md
@@ -1,196 +1,30 @@
 # snowplow-iglu-server
 
-A helm chart for [Snowplow Iglu Server](https://github.com/snowplow-incubator/iglu-server).
+![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![AppVersion: 0.13.0](https://img.shields.io/badge/AppVersion-0.13.0-informational?style=flat-square)
 
-## TL;DR
+A Helm Chart to deploy the Snowplow Iglu Server project
 
-```bash
-helm repo add snowplow-devops https://snowplow-devops.github.io/helm-charts
-helm install snowplow-iglu-server snowplow-devops/snowplow-iglu-server
-```
+**Homepage:** <https://github.com/snowplow-devops/helm-charts>
 
-## Introduction
+## Maintainers
 
-This chart deploys a Snowplow Iglu Server on a Kubernetes cluster using the Helm package manager.  For demonstration purposes the system is deployed with an "in-memory" database.  Configure a "postgres" backend for production use-cases.
+| Name | Email | Url |
+| ---- | ------ | --- |
+| jbeemster | <jbeemster@users.noreply.github.com> | <https://github.com/jbeemster> |
 
-## Installing the Chart
+## Source Code
 
-Install or upgrading the chart with default configuration:
+* <https://github.com/snowplow-devops/helm-charts>
+* <https://github.com/snowplow-incubator/iglu-server>
 
-```bash
-helm upgrade --install snowplow-iglu-server snowplow-devops/snowplow-iglu-server
-```
+## Requirements
 
-## Uninstalling the Chart
+| Repository | Name | Version |
+|------------|------|---------|
+| https://snowplow-devops.github.io/helm-charts | cloudserviceaccount | 0.3.0 |
+| https://snowplow-devops.github.io/helm-charts | dockerconfigjson | 0.1.0 |
 
-To uninstall/delete the `snowplow-iglu-server` release:
-
-```bash
-helm delete snowplow-iglu-server
-```
-
-## Deployment options
-
-The most common settings we expect users to leverage are exposed as inputs under the `service.config.*` key.
-
-If however you need to tune other settings you can also optionally provide a base64 encoded HOCON in the `service.config.hoconBase64`.  It is important to remember however that the settings being defined in the common settings will *always* take precedence over anything you define in the config.
-
-### Backend: Postgres
-
-1. Configure a PostgreSQL backend
-  - As an example you can use: https://artifacthub.io/packages/helm/bitnami/postgresql
-  - You will need the endpoint, username, password, port and database name
-2. Make a copy of `values-local.yaml.tmpl` and call it `values-local.yaml`
-3. Sub in the database values from step 1
-4. Run: `helm upgrade --install snowplow-iglu-server --values values-local.yaml .`
-  - Make sure to target the same namespace as your PostgresDB (assumption is `default`)
-
-You can then port-forward the deployment to access it from your host:
-
-```bash
-kubectl port-forward --namespace default svc/snowplow-iglu-server-iglu-app 8080:8080
-```
-
-_Note_: This assumes 8080 is available on your host and you have used the default bind port of 8080.
-
-You can then use the Iglu Server as normal leveraging the APIKey you generated earlier and `localhost:8080` as your endpoint (e.g. `curl http://localhost:8080/static/swagger-ui/index.html`).
-
-### AWS (EKS) settings
-
-#### TargetGroup binding
-
-To manage the load balancer externally to the kubernetes cluster you can bind the deployment to an existing TargetGroup ARN.  Its important that the TargetGroup exist ahead of time and that you use the same port as you have used in your `values.yaml`. 
-
-*Note*: Before this will work you will need to install the `aws-load-balancer-controller-crds` and `aws-load-balancer-controller` charts into your EKS cluster.
-
-You will need to fill these targeted fields:
-
-- `global.cloud: "aws"`
-- `service.aws.targetGroupARN: "<target_group_arn>"`
-
-### GCP (GKE) settings
-
-#### Backend: CloudSQL Postgres with proxy
-
-To ease deployment to a GKE cluster you can optionally leverage the built-in CloudSQL proxy - this will create a service deployment exposing your CloudSQL instance within your cluster.
-
-To take advantage of this you will need to bind a service-account to the deployment which, in Terraform, looks something like the following:
-
-```hcl
-resource "google_service_account" "snowplow_iglu_server" {
-  account_id   = "snowplow-iglu-server"
-  display_name = "Snowplow Iglu Server service account"
-}
-
-resource "google_service_account_iam_binding" "snowplow_iglu_server_sa_wiu_binding" {
-  role = "roles/iam.workloadIdentityUser"
-  members = [
-    "serviceAccount:<project>.svc.id.goog[<namespace>/<release_name>]",
-    "serviceAccount:<project>.svc.id.goog[<namespace>/<release_name>-csp]"
-  ]
-  service_account_id = google_service_account.snowplow_iglu_server.id
-}
-
-resource "google_project_iam_member" "snowplow_iglu_server_sa_cloudsql_client" {
-  role   = "roles/cloudsql.client"
-  member = "serviceAccount:${google_service_account.snowplow_iglu_server.email}"
-}
-
-output "snowplow_iglu_server_sa_account_email" {
-  value = google_service_account.snowplow_iglu_server.email
-}
-```
-
-You can then use the resulting value as an input to `cloudserviceaccount.gcp.serviceAccount` which will allow the CloudSQL deployment to access the database.
-
-You will need to fill these targeted fields:
-
-- `global.cloud: "gcp"`
-- `service.gcp.deployProxy: true`
-- `service.gcp.proxy.port: <some_value>`
-- `service.gcp.proxy.project: <project>`
-- `service.gcp.proxy.region: <region>`
-- `service.gcp.proxy.instanceName: <db_instance_name>`
-- `service.gcp.proxy.ipAddressTypes: <PUBLIC|PRIVATE|PSC>` (optional, defaults to PUBLIC)
-- `cloudserviceaccount.deploy: true`
-- `cloudserviceaccount.name: <unique_name>`
-- `cloudserviceaccount.gcp.serviceAccount: <output_value_from_above>`
-
-*Note*: As the iglu deployment and setup hooks depend on this service it is normal to expect a few initial failures to occur - they should automatically resolve without intervention.
-
-## Database Setup and Teardown Hooks
-
-The chart includes Helm hooks for automated database and user initialization when using PostgreSQL as the backend.
-
-### Setup Hooks
-
-Setup hooks run after installation (`post-install`) and upgrades (`post-upgrade`) to prepare the database environment:
-
-1. **Database Initialization Hook** (`hooks.deploySetupHooks: true`)
-   - Creates database user if `hooks.deployDBUser: true`
-   - Creates database if `hooks.deployDB: true` 
-   - Grants privileges to the user if `hooks.deployDBUserGrants: true`. Required if the database is created separately.
-   - Runs with `helm.sh/hook-weight: "1"` (before Iglu Server setup)
-
-2. **Iglu Setup Hook** (automatically runs when `hooks.deploySetupHooks: true`)
-   - Initializes Iglu Server database schema and configuration
-   - Runs with `helm.sh/hook-weight: "2"` (after database / user initialization)
-
-### Destroy Hooks
-
-Destroy hooks run before deletion (`pre-delete`) to clean up database resources:
-
-- **Database Cleanup Hook** (`hooks.deployDestroyHooks: true`)
-  - Drops database if `hooks.destroyDB: true`
-  - Drops database user if `hooks.destroyDBUser: true`
-  - Requires admin credentials for cleanup operations
-
-### Configuration
-
-To use hooks, you need to provide administrative database credentials:
-
-```yaml
-hooks:
-  deploySetupHooks: true
-  deployDBUser: true
-  deployDB: true
-  deployDBUserGrants: true
-  image:
-    repository: "postgres"    # PostgreSQL client image repository
-    tag: "15-alpine"          # PostgreSQL client image tag
-    pullPolicy: "Always"      # Image pull policy for hook containers
-  connectionTimeout: 10       # Connection timeout in seconds for PostgreSQL connections
-  defaultDBName: "postgres"   # Database to connect to for admin operations
-  secrets:
-    admin_username: "postgres"
-    admin_password: "your-admin-password"
-
-service:
-  config:
-    database:
-      type: "postgres"
-      host: "your-postgres-host"
-      port: 5432
-      dbname: "iglu_db"  # Database to create/use for Iglu
-      secrets:
-        username: "iglu_user"  # User to create for Iglu
-        password: "iglu-password"
-```
-
-### Hook Execution Order
-
-1. **Installation/Upgrade**:
-   - Database initialization hook (weight: 1) - Creates user, database, grants permissions
-   - Iglu setup hook (weight: 2) - Initializes Iglu schema
-   - Main deployment starts
-
-2. **Deletion**:
-   - Main deployment stops
-   - Database cleanup hook - Drops database and user (if configured)
-
-*Note*: Hooks are only active when `service.config.database.type` is set to `"postgres"`.
-
-## Configuration
+## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -205,22 +39,20 @@ service:
 | dockerconfigjson.username | string | `""` | Username for the private repository |
 | fullnameOverride | string | `""` | Overrides the full-name given to the deployment resources (default: .Release.Name) |
 | global.cloud | string | `""` | Cloud specific bindings (options: aws, gcp, azure) |
-| global.labels | object | `{}` | Global labels deployed to all resources deployed by the chart |
-| hooks.deploySetupHooks | bool | `false` | Whether to run the post-deploy setup hooks to create database and user |
-| hooks.deployDestroyHooks | bool | `false` | Whether to run the pre-delete destroy hooks to clean up database and user |
-| hooks.deployDBUser | bool | `false` | Whether the setup hook should create the database user |
-| hooks.deployDBUserGrants | bool | `false` | Whether the setup hook should grant privileges to the database user |
-| hooks.deployDB | bool | `false` | Whether the setup hook should create the database |
-| hooks.destroyDBUser | bool | `false` | Whether the destroy hook should drop the database user |
-| hooks.destroyDB | bool | `false` | Whether the destroy hook should drop the database |
-| hooks.defaultDBName | string | `"postgres"` | Default database name to connect to for administrative operations |
-| hooks.image.repository | string | `"postgres"` | PostgreSQL client image repository for hooks |
-| hooks.image.tag | string | `"15-alpine"` | PostgreSQL client image tag for hooks |
-| hooks.image.pullPolicy | string | `"Always"` | Image pull policy for hook containers |
+| global.labels | object | `{}` |  |
 | hooks.connectionTimeout | int | `10` | Connection timeout in seconds for PostgreSQL connections |
-| hooks.secrets.admin_username | string | `""` | Admin username for database operations in hooks |
-| hooks.secrets.admin_password | string | `""` | Admin password for database operations in hooks |
-| service.annotations | object | `{}` | Map of annotations to add to the service |
+| hooks.defaultDBName | string | `"postgres"` | Default database name and admin credentials for hooks to use |
+| hooks.deployDB | bool | `false` |  |
+| hooks.deployDBUser | bool | `false` |  |
+| hooks.deployDBUserGrants | bool | `false` |  |
+| hooks.deployDestroyHooks | bool | `false` |  |
+| hooks.deploySetupHooks | bool | `false` | Whether to run the post-deploy setup hooks to create database and user |
+| hooks.destroyDB | bool | `false` |  |
+| hooks.destroyDBUser | bool | `false` | Whether to run the pre-delete destroy hooks to drop database and user |
+| hooks.image | object | `{"pullPolicy":"Always","repository":"postgres","tag":"15-alpine"}` | PostgreSQL client image configuration for hooks |
+| hooks.secrets.admin_password | string | `""` |  |
+| hooks.secrets.admin_username | string | `""` |  |
+| service.annotations | object | `{}` | Map of annotations to add to the service. |
 | service.aws.targetGroupARN | string | `""` | EC2 TargetGroup ARN to bind the service onto |
 | service.config.database.dbname | string | `""` | Postgres database name |
 | service.config.database.host | string | `""` | Postgres database host |
@@ -228,19 +60,23 @@ service:
 | service.config.database.secrets.password | string | `""` |  |
 | service.config.database.secrets.username | string | `""` |  |
 | service.config.database.type | string | `"dummy"` | Can be either 'dummy' (in-memory) or 'postgres' |
+| service.config.env | object | `{"ACCEPT_LIMITED_USE_LICENSE":"no"}` | Map of additional environment variables to use within the deployment |
 | service.config.hoconBase64 | string | `""` | Optional Base64 encoded config HOCON (note: will not override above settings) |
 | service.config.javaOpts | string | `""` | Optional JAVA_OPTS inputs for the deployed service |
 | service.config.patchesAllowed | bool | `false` | Whether to allow schema patching |
+| service.config.repoServer.hsts.enable | bool | `true` |  |
 | service.config.repoServer.idleTimeout | string | `"65 seconds"` |  |
 | service.config.repoServer.maxConnections | int | `16384` |  |
-| service.config.repoServer.hsts.enable | bool | `true` | Whether to enable sending HSTS headers (>=0.12.0) |
 | service.config.secrets.superApiKey | string | `""` | Lowercase uuidv4 to use as admin apikey of the service (default: auto-generated) |
+| service.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":false,"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context configuration These defaults follow kubesec.io best practices for hardened deployments.  runAsUser is pinned to 65534 (nobody) because the upstream snowplow/iglu-server distroless image declares USER nobody — a non-numeric value that the kubelet cannot verify against runAsNonRoot. Pinning the numeric UID lets runAsNonRoot pass without changing the runtime user.  readOnlyRootFilesystem defaults to false so existing deployments are not broken on upgrade; set it to true per-deployment once writable paths (e.g. /tmp) are mounted as emptyDirs. |
+| service.extraVolumeMounts | list | `[]` | Additional volume mounts to attach to the container. Pair with extraVolumes above. |
+| service.extraVolumes | list | `[]` | Additional volumes to attach to the pod spec. Useful with readOnlyRootFilesystem: true — declare writable scratch space (e.g. emptyDir on /tmp) without disabling the hardened default. |
 | service.gcp.deployProxy | bool | `false` | Whether to use CloudSQL Proxy (note: requires GCP service account to be attached) |
 | service.gcp.proxy.image.isRepositoryPublic | bool | `true` | Whether the repository is public |
 | service.gcp.proxy.image.repository | string | `"gcr.io/cloudsql-docker/gce-proxy"` |  |
 | service.gcp.proxy.image.tag | string | `"1.31.2"` |  |
 | service.gcp.proxy.instanceName | string | `""` | Name of the CloudSQL instance |
-| service.gcp.proxy.ipAddressTypes | string | `"PUBLIC"` | IP address types to use (options: PUBLIC, PRIVATE, PSC) |
+| service.gcp.proxy.ipAddressTypes | string | `"PUBLIC"` | IP address types to use (options: PUBLIC, PRIVATE, PSC; default: PUBLIC) |
 | service.gcp.proxy.port | int | `38000` | Port to bind proxy onto |
 | service.gcp.proxy.project | string | `""` | Project where CloudSQL instance is deployed |
 | service.gcp.proxy.region | string | `""` | Region where CloudSQL instance is deployed |
@@ -251,15 +87,18 @@ service:
 | service.image.isRepositoryPublic | bool | `true` | Whether the repository is public |
 | service.image.pullPolicy | string | `"IfNotPresent"` | The image pullPolicy to use |
 | service.image.repository | string | `"snowplow/iglu-server"` |  |
-| service.image.tag | string | `"0.10.0-distroless"` |  |
+| service.image.tag | string | `"0.12.0-distroless"` |  |
 | service.ingress | object | `{}` | A map of ingress rules to deploy |
-| service.maxReplicas | int | `4` |  |
-| service.minReplicas | int | `1` |  |
-| service.port | int | `8080` | Port to bind and expose the service on |
+| service.ingressIPAllowlist | list | `[]` | List of IP addresses to restrict ingress traffic to |
 | service.livenessProbe.failureThreshold | int | `3` |  |
 | service.livenessProbe.initialDelaySeconds | int | `30` |  |
 | service.livenessProbe.periodSeconds | int | `5` |  |
 | service.livenessProbe.timeoutSeconds | int | `5` |  |
+| service.maxReplicas | int | `4` |  |
+| service.minReplicas | int | `1` |  |
+| service.podDisruptionBudget.enabled | bool | `false` | Whether to deploy a PodDisruptionBudget |
+| service.podDisruptionBudget.minAvailable | int | `1` | Minimum number (or percentage) of pods that must remain available. Mutually exclusive with maxUnavailable. |
+| service.port | int | `8080` | Port to bind and expose the service on |
 | service.readinessProbe.failureThreshold | int | `3` |  |
 | service.readinessProbe.initialDelaySeconds | int | `5` |  |
 | service.readinessProbe.periodSeconds | int | `5` |  |
@@ -271,5 +110,8 @@ service:
 | service.resources.requests.memory | string | `"512Mi"` |  |
 | service.targetCPUUtilizationPercentage | int | `75` |  |
 | service.terminationGracePeriodSeconds | int | `630` |  |
-| service.tolerations | list |`[]` | Tolerations labels for pod assignment with matching taints |
-| service.topologySpreadConstraints | object | `{}` | Topology Spread Constraints for pod assignment |
+| service.tolerations | list | `[]` | Allow the scheduler to schedule pods with matching taints  more details here: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
+| service.topologySpreadConstraints | object | `{}` | topologySpreadConstraints control how Pods are  spread across your cluster among failure-domains such as regions, zones, nodes, and other user-defined topology domains.  more details here: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/ |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/snowplow-iglu-server/templates/iglu-deployment.yaml
+++ b/charts/snowplow-iglu-server/templates/iglu-deployment.yaml
@@ -43,11 +43,17 @@ spec:
           optional: false
         name: {{ include "iglu.app.config.name" . }}-volume
       {{- end }}
+      {{- with .Values.service.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
 
       containers:
       - name: {{ include "iglu.app.name" . }}
         image: {{ .Values.service.image.repository}}:{{ .Values.service.image.tag}}
         imagePullPolicy: {{ default "IfNotPresent" .Values.service.image.pullPolicy }}
+
+        securityContext:
+          {{- toYaml .Values.service.containerSecurityContext | nindent 10 }}
 
         args:
         - "--config"
@@ -123,4 +129,7 @@ spec:
         - mountPath: /etc/config
           mountPropagation: None
           name: {{ include "iglu.app.config.name" . }}-volume
+        {{- end }}
+        {{- with .Values.service.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/snowplow-iglu-server/values.yaml
+++ b/charts/snowplow-iglu-server/values.yaml
@@ -57,6 +57,41 @@ service:
       cpu: 400m
       memory: 512Mi
 
+  # -- Container security context configuration
+  # These defaults follow kubesec.io best practices for hardened deployments.
+  #
+  # runAsUser / runAsGroup are intentionally not pinned. Different container
+  # images bake in different non-root USER directives, and forcing a specific
+  # UID can prevent the image's user from accessing its own files. The image's
+  # USER directive selects the runtime UID; runAsNonRoot: true still enforces
+  # the non-root invariant. Override per-deployment if you need a specific UID.
+  #
+  # readOnlyRootFilesystem defaults to false so existing deployments are not
+  # broken on upgrade; set it to true per-deployment once writable paths
+  # (e.g. /tmp) are mounted as emptyDirs.
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    readOnlyRootFilesystem: false
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+
+  # -- Additional volumes to attach to the pod spec.
+  # Useful with readOnlyRootFilesystem: true — declare writable scratch space
+  # (e.g. emptyDir on /tmp) without disabling the hardened default.
+  extraVolumes: []
+  #  - name: tmp
+  #    emptyDir: {}
+
+  # -- Additional volume mounts to attach to the container.
+  # Pair with extraVolumes above.
+  extraVolumeMounts: []
+  #  - name: tmp
+  #    mountPath: /tmp
+
   podDisruptionBudget:
     # -- Whether to deploy a PodDisruptionBudget
     enabled: false

--- a/charts/snowplow-iglu-server/values.yaml
+++ b/charts/snowplow-iglu-server/values.yaml
@@ -60,11 +60,10 @@ service:
   # -- Container security context configuration
   # These defaults follow kubesec.io best practices for hardened deployments.
   #
-  # runAsUser / runAsGroup are intentionally not pinned. Different container
-  # images bake in different non-root USER directives, and forcing a specific
-  # UID can prevent the image's user from accessing its own files. The image's
-  # USER directive selects the runtime UID; runAsNonRoot: true still enforces
-  # the non-root invariant. Override per-deployment if you need a specific UID.
+  # runAsUser is pinned to 65534 (nobody) because the upstream
+  # snowplow/iglu-server distroless image declares USER nobody — a non-numeric
+  # value that the kubelet cannot verify against runAsNonRoot. Pinning the
+  # numeric UID lets runAsNonRoot pass without changing the runtime user.
   #
   # readOnlyRootFilesystem defaults to false so existing deployments are not
   # broken on upgrade; set it to true per-deployment once writable paths
@@ -72,6 +71,7 @@ service:
   containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsNonRoot: true
+    runAsUser: 65534
     readOnlyRootFilesystem: false
     capabilities:
       drop:


### PR DESCRIPTION
Adds container-level hardening defaults across the three workload charts, along with the escape hatches needed to enable strict mode on a per-deployment basis.

* `containerSecurityContext` added to `service-deployment`, `cron-job`, and `snowplow-iglu-server`:

  * `allowPrivilegeEscalation: false`
  * `runAsNonRoot: true`
  * `capabilities.drop: [ALL]`
  * `seccompProfile: RuntimeDefault`
  * `readOnlyRootFilesystem` defaults to `false` to avoid breaking upgrades; this can be enabled per deployment when ready.

* No UID pinning:

  * Defers to the image’s `USER` directive.
  * `runAsNonRoot: true` enforces the non-root requirement.
  * Still overridable per deployment if needed.

* Added `extraVolumes` and `extraVolumeMounts` to all three charts so consumers can mount writable scratch volumes (for example, an `emptyDir` mounted on `/tmp`) and safely enable `readOnlyRootFilesystem: true`.

* Added `config.workingDir` to both `service-deployment` and `cron-job` charts for applications that write to their current working directory.

* Chart version bumps:

  * `service-deployment` → `0.41.0`
  * `cron-job` → `0.15.0`
  * `snowplow-iglu-server` → `0.18.0`

* Added CHANGELOG entry for `0.3.36`.

This change is designed to be non-breaking — the defaults preserve current behavior, while the hardening features are opt-in through values overrides.
