### PR TITLE
charts/aws-otel-collector-0.14.0: Bump version used to 0.48.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.3.37 (2026-05-26)
+---------------------------
+charts/aws-otel-collector-0.14.0: Bump version used to 0.48.0 (#335)
+
 Version 0.3.36 (2026-05-14)
 ---------------------------
 charts/service-deployment-0.41.0: Add containerSecurityContext with kubesec.io hardened defaults; add extraVolumes, extraVolumeMounts and config.workingDir

--- a/charts/aws-otel-collector/Chart.yaml
+++ b/charts/aws-otel-collector/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-otel-collector
 description: A Helm chart to deploy aws-otel-collector project
-version: 0.13.0
-appVersion: "v0.47.0"
+version: 0.14.0
+appVersion: "v0.48.0"
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/aws-otel-collector/values.yaml
+++ b/charts/aws-otel-collector/values.yaml
@@ -8,7 +8,7 @@ clusterName: ""
 image:
   # -- Image to use for deploying
   repository: public.ecr.aws/aws-observability/aws-otel-collector
-  tag: v0.47.0
+  tag: v0.48.0
   pullPolicy: IfNotPresent
 
 # -- Pod/container securityContext for the collector. Defaults to running as root


### PR DESCRIPTION
charts/aws-otel-collector-0.14.0: Bump version used to 0.48.0 (#335 )