### PR TITLE
[QA-780] charts/avalanche 0.7.0: add sizing presets (small/medium/large)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.3.40 (2026-06-11)
+---------------------------
+charts/avalanche-0.7.0: Add sizing presets (small/medium/large) for resource defaults. New top-level sizingPreset (default medium) backed by a presets map, resolved per-component via _helpers.tpl (componentResources / componentReplicas / injectorWorkers); per-component resources/replicas/workers overrides still win. Lets a default install sustain real load instead of the old demo-sized defaults.
+
 Version 0.3.39 (2026-06-10)
 ---------------------------
 charts/avalanche-0.6.5: observer-kubernetes IRSA fix — new avalanche.observerKubernetes.serviceAccountName helper reuses cloudserviceaccount (inheriting its Timestream IRSA role) when deployed, else the dedicated SA, so the api observer no longer falls back to the node role and crash-loops on a Timestream 403 under DS4. Restore hasKey (not default) for the cloudwatch per-target podNamePattern/podNameReplacement so podNamePattern: "" disables the regex as documented. Guard cloudserviceaccount.name with required so an empty reused-SA name fails fast instead of rendering invalid RBAC. (#337)

--- a/charts/avalanche/Chart.yaml
+++ b/charts/avalanche/Chart.yaml
@@ -3,7 +3,7 @@ name: avalanche
 description: A Helm chart for Avalanche - Progressive load testing framework for Snowplow infrastructure
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 type: application
-version: 0.6.5
+version: 0.7.0
 appVersion: "1.0.0"
 keywords:
   - avalanche

--- a/charts/avalanche/README.md
+++ b/charts/avalanche/README.md
@@ -16,7 +16,7 @@ sizingPreset: medium  # small | medium | large
 | `medium` (default) | 2000m / 2Gi | 1 / 50 | Sustained multi-k RPS. Designed for ~2000 RPS at the collector, validated with single-injector-pod headroom around 8% CPU at 400 RPS. |
 | `large` | 4000m / 4Gi | 1 / 100 | High-throughput perf baselines. Single injector pod with maximum CPU/memory/workers. Multi-replica orchestration is tracked separately — all presets currently pin `injector.replicas` to 1. |
 
-Non-injector components (controller, observer, correlator, adjudicator, aggregator, observerKubernetes, aggregatorKubernetes, mockTarget, nats) scale roughly proportionally across the three presets — see `presets:` in `values.yaml` for the full table.
+Non-injector components (controller, observer, correlator, adjudicator, aggregator, observerKubernetes, aggregatorKubernetes, nats) scale roughly proportionally across the three presets — see `presets:` in `values.yaml` for the full table. `mockTarget` and `aggregatorKinesisStream` are **not** preset-driven — they keep their own `replicas`/`resources` defaults regardless of `sizingPreset`.
 
 ### Overriding per component
 

--- a/charts/avalanche/README.md
+++ b/charts/avalanche/README.md
@@ -1,0 +1,59 @@
+# Avalanche Helm Chart
+
+Progressive load-testing framework for Snowplow data pipelines.
+
+## Sizing presets
+
+The chart's resource defaults are driven by a top-level `sizingPreset` value. This avoids consumers having to override per-component CPU/memory/replicas/workers just to lift the injector above the smoke-test ceiling.
+
+```yaml
+sizingPreset: medium  # small | medium | large
+```
+
+| Preset | Injector CPU / mem | Injector replicas / workers | Intent |
+| --- | --- | --- | --- |
+| `small` | 500m / 256Mi | 1 / 3 | Smoke tests, kind / docker-desktop. Equivalent to the pre-0.3.0 chart defaults. |
+| `medium` (default) | 2000m / 2Gi | 1 / 50 | Sustained multi-k RPS. Designed for ~2000 RPS at the collector, validated with single-injector-pod headroom around 8% CPU at 400 RPS. |
+| `large` | 4000m / 4Gi | 1 / 100 | High-throughput perf baselines. Single injector pod with maximum CPU/memory/workers. Multi-replica orchestration is tracked separately — all presets currently pin `injector.replicas` to 1. |
+
+Non-injector components (controller, observer, correlator, adjudicator, aggregator, observerKubernetes, aggregatorKubernetes, mockTarget, nats) scale roughly proportionally across the three presets — see `presets:` in `values.yaml` for the full table.
+
+### Overriding per component
+
+Per-component `<component>.resources`, `<component>.replicas`, and `injector.config.workers` overrides win over the preset whenever they're set to a non-zero / non-empty value. The override is **all-or-nothing** — if you override `<component>.resources`, you replace the entire preset block, not just one field.
+
+```yaml
+# Use the medium preset for everything except injector — pin injector explicitly.
+sizingPreset: medium
+injector:
+  replicas: 5
+  config:
+    workers: 200
+  resources:
+    requests: { cpu: "1500m", memory: "1Gi" }
+    limits:   { cpu: "3000m", memory: "3Gi" }
+```
+
+### Adding a new preset
+
+Add an entry to `presets:` in your values override and point `sizingPreset` at it:
+
+```yaml
+sizingPreset: my-custom
+
+presets:
+  my-custom:
+    injector:
+      replicas: 2
+      workers: 75
+      resources:
+        requests: { cpu: "750m", memory: "768Mi" }
+        limits:   { cpu: "3000m", memory: "3Gi" }
+    # … other components …
+```
+
+The chart resolves preset values via the `avalanche.componentResources`, `avalanche.componentReplicas`, and `avalanche.injectorWorkers` helpers in `templates/_helpers.tpl`.
+
+## Background
+
+The pre-0.3.0 chart shipped a single set of resource defaults sized for demos, not for load generation. At 500 RPS the injector OOMKilled, took a heartbeat-miss restart, then fell off the NATS rate update. Consumers (snowman sandbox path, DS4 collector tests) carried per-field overrides in their own values.yaml templates to work around this. Presets centralise the sizing decision in the chart so consumers can pick a preset and stop carrying overrides — see ticket QA-780 for the full design and the calibration data behind these numbers.

--- a/charts/avalanche/README.md
+++ b/charts/avalanche/README.md
@@ -10,7 +10,7 @@ The chart's resource defaults are driven by a top-level `sizingPreset` value. Th
 sizingPreset: medium  # small | medium | large
 ```
 
-| Preset | Injector CPU / mem | Injector replicas / workers | Intent |
+| Preset | Injector CPU / mem (limit) | Injector replicas / workers | Intent |
 | --- | --- | --- | --- |
 | `small` | 500m / 256Mi | 1 / 3 | Smoke tests, kind / docker-desktop. Equivalent to the pre-0.3.0 chart defaults. |
 | `medium` (default) | 2000m / 2Gi | 1 / 50 | Sustained multi-k RPS. Designed for ~2000 RPS at the collector, validated with single-injector-pod headroom around 8% CPU at 400 RPS. |

--- a/charts/avalanche/templates/NOTES.txt
+++ b/charts/avalanche/templates/NOTES.txt
@@ -56,8 +56,9 @@ kubectl get pods -n {{ .Release.Namespace }}
 kubectl logs -f deployment/{{ include "avalanche.fullname" . }}-controller -n {{ .Release.Namespace }}
 kubectl logs -f deployment/{{ include "avalanche.fullname" . }}-injector -n {{ .Release.Namespace }}
 
-# Switch sizing preset (small | medium | large)
-helm upgrade {{ .Release.Name }} ./charts/avalanche --set sizingPreset=large
+# Switch sizing preset (small | medium | large). Replace <chart> with the chart
+# reference you installed from (e.g. a Helm repo ref like snowplow-devops/avalanche).
+helm upgrade {{ .Release.Name }} <chart> --reuse-values --set sizingPreset=large
 
 # Uninstall
 helm uninstall {{ .Release.Name }} -n {{ .Release.Namespace }}

--- a/charts/avalanche/templates/NOTES.txt
+++ b/charts/avalanche/templates/NOTES.txt
@@ -57,7 +57,7 @@ kubectl logs -f deployment/{{ include "avalanche.fullname" . }}-controller -n {{
 kubectl logs -f deployment/{{ include "avalanche.fullname" . }}-injector -n {{ .Release.Namespace }}
 
 # Switch sizing preset (small | medium | large)
-helm upgrade {{ .Release.Name }} ./helm/avalanche --set sizingPreset=large
+helm upgrade {{ .Release.Name }} ./charts/avalanche --set sizingPreset=large
 
 # Uninstall
 helm uninstall {{ .Release.Name }} -n {{ .Release.Namespace }}

--- a/charts/avalanche/templates/NOTES.txt
+++ b/charts/avalanche/templates/NOTES.txt
@@ -10,20 +10,22 @@ Components deployed:
   - NATS (messaging)
 {{- end }}
 {{- if .Values.injector.enabled }}
-  - Injector (load generation) - {{ .Values.injector.replicas }} replica(s)
+  - Injector (load generation) - {{ include "avalanche.componentReplicas" (dict "ctx" . "component" "injector") }} replica(s)
 {{- end }}
 {{- if .Values.observer.enabled }}
-  - Observer (monitoring) - {{ .Values.observer.replicas }} replica(s)
+  - Observer (monitoring) - {{ include "avalanche.componentReplicas" (dict "ctx" . "component" "observer") }} replica(s)
 {{- end }}
 {{- if .Values.correlator.enabled }}
-  - Correlator (correlation) - {{ .Values.correlator.replicas }} replica(s)
+  - Correlator (correlation) - {{ include "avalanche.componentReplicas" (dict "ctx" . "component" "correlator") }} replica(s)
 {{- end }}
 {{- if .Values.adjudicator.enabled }}
-  - Adjudicator (validation) - {{ .Values.adjudicator.replicas }} replica(s)
+  - Adjudicator (validation) - {{ include "avalanche.componentReplicas" (dict "ctx" . "component" "adjudicator") }} replica(s)
 {{- end }}
 {{- if .Values.controller.enabled }}
-  - Controller (orchestration) - {{ .Values.controller.replicas }} replica(s)
+  - Controller (orchestration) - {{ include "avalanche.componentReplicas" (dict "ctx" . "component" "controller") }} replica(s)
 {{- end }}
+
+Sizing preset: {{ .Values.sizingPreset }}
 
 =======================================================================
   Access Information
@@ -54,8 +56,8 @@ kubectl get pods -n {{ .Release.Namespace }}
 kubectl logs -f deployment/{{ include "avalanche.fullname" . }}-controller -n {{ .Release.Namespace }}
 kubectl logs -f deployment/{{ include "avalanche.fullname" . }}-injector -n {{ .Release.Namespace }}
 
-# Scale injector replicas
-helm upgrade {{ .Release.Name }} ./helm/avalanche --set injector.replicas=3
+# Switch sizing preset (small | medium | large)
+helm upgrade {{ .Release.Name }} ./helm/avalanche --set sizingPreset=large
 
 # Uninstall
 helm uninstall {{ .Release.Name }} -n {{ .Release.Namespace }}

--- a/charts/avalanche/templates/_helpers.tpl
+++ b/charts/avalanche/templates/_helpers.tpl
@@ -101,6 +101,9 @@ Usage:
 {{- toYaml $override -}}
 {{- else -}}
 {{- $preset := include "avalanche.presetComponent" (dict "ctx" $ctx "component" $component) | fromYaml -}}
+{{- if not (hasKey $preset "resources") -}}
+{{- fail (printf "avalanche: sizingPreset %q component %q is missing a 'resources' block" $ctx.Values.sizingPreset $component) -}}
+{{- end -}}
 {{- toYaml $preset.resources -}}
 {{- end -}}
 {{- end }}
@@ -120,6 +123,9 @@ Usage:
 {{- $override | int -}}
 {{- else -}}
 {{- $preset := include "avalanche.presetComponent" (dict "ctx" $ctx "component" $component) | fromYaml -}}
+{{- if not (hasKey $preset "replicas") -}}
+{{- fail (printf "avalanche: sizingPreset %q component %q is missing 'replicas'" $ctx.Values.sizingPreset $component) -}}
+{{- end -}}
 {{- $preset.replicas | int -}}
 {{- end -}}
 {{- end }}
@@ -137,6 +143,9 @@ Usage in configmap.yaml:
 {{- $override | int -}}
 {{- else -}}
 {{- $preset := include "avalanche.presetComponent" (dict "ctx" . "component" "injector") | fromYaml -}}
+{{- if not (hasKey $preset "workers") -}}
+{{- fail (printf "avalanche: sizingPreset %q injector block is missing 'workers'" .Values.sizingPreset) -}}
+{{- end -}}
 {{- $preset.workers | int -}}
 {{- end -}}
 {{- end }}

--- a/charts/avalanche/templates/_helpers.tpl
+++ b/charts/avalanche/templates/_helpers.tpl
@@ -85,6 +85,62 @@ nats://{{ include "avalanche.fullname" . }}-nats:{{ .Values.nats.service.clientP
 {{- end }}
 
 {{/*
+Resolve component resources: per-component override wins, otherwise the value
+from the active sizing preset (`.Values.presets.<sizingPreset>.<component>.resources`).
+A non-empty `<component>.resources` map counts as an override.
+
+Usage:
+  resources:
+    {{- include "avalanche.componentResources" (dict "ctx" . "component" "injector") | nindent 12 }}
+*/}}
+{{- define "avalanche.componentResources" -}}
+{{- $ctx := .ctx -}}
+{{- $component := .component -}}
+{{- $override := (index $ctx.Values $component "resources") | default dict -}}
+{{- $preset := index $ctx.Values.presets $ctx.Values.sizingPreset $component -}}
+{{- if gt (len $override) 0 -}}
+{{- toYaml $override -}}
+{{- else -}}
+{{- toYaml $preset.resources -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Resolve component replicas: per-component override wins (any non-zero integer),
+otherwise the value from the active sizing preset.
+
+Usage:
+  replicas: {{ include "avalanche.componentReplicas" (dict "ctx" . "component" "injector") }}
+*/}}
+{{- define "avalanche.componentReplicas" -}}
+{{- $ctx := .ctx -}}
+{{- $component := .component -}}
+{{- $override := (index $ctx.Values $component "replicas") | default 0 -}}
+{{- $preset := index $ctx.Values.presets $ctx.Values.sizingPreset $component -}}
+{{- if gt ($override | int) 0 -}}
+{{- $override -}}
+{{- else -}}
+{{- $preset.replicas -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Resolve injector workers: `.Values.injector.config.workers` override wins (any
+non-zero integer), otherwise the value from the active sizing preset.
+
+Usage in configmap.yaml:
+  workers: {{ include "avalanche.injectorWorkers" . }}
+*/}}
+{{- define "avalanche.injectorWorkers" -}}
+{{- $override := .Values.injector.config.workers | default 0 -}}
+{{- if gt ($override | int) 0 -}}
+{{- $override -}}
+{{- else -}}
+{{- index .Values.presets .Values.sizingPreset "injector" "workers" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Image name helper - supports both local and registry images
 If images.registry is empty, uses local image format: repository:tag
 If images.registry is set, uses registry format: registry/repository:tag

--- a/charts/avalanche/templates/_helpers.tpl
+++ b/charts/avalanche/templates/_helpers.tpl
@@ -97,10 +97,10 @@ Usage:
 {{- $ctx := .ctx -}}
 {{- $component := .component -}}
 {{- $override := (index $ctx.Values $component "resources") | default dict -}}
-{{- $preset := index $ctx.Values.presets $ctx.Values.sizingPreset $component -}}
 {{- if gt (len $override) 0 -}}
 {{- toYaml $override -}}
 {{- else -}}
+{{- $preset := include "avalanche.presetComponent" (dict "ctx" $ctx "component" $component) | fromYaml -}}
 {{- toYaml $preset.resources -}}
 {{- end -}}
 {{- end }}
@@ -116,11 +116,11 @@ Usage:
 {{- $ctx := .ctx -}}
 {{- $component := .component -}}
 {{- $override := (index $ctx.Values $component "replicas") | default 0 -}}
-{{- $preset := index $ctx.Values.presets $ctx.Values.sizingPreset $component -}}
 {{- if gt ($override | int) 0 -}}
-{{- $override -}}
+{{- $override | int -}}
 {{- else -}}
-{{- $preset.replicas -}}
+{{- $preset := include "avalanche.presetComponent" (dict "ctx" $ctx "component" $component) | fromYaml -}}
+{{- $preset.replicas | int -}}
 {{- end -}}
 {{- end }}
 
@@ -134,10 +134,31 @@ Usage in configmap.yaml:
 {{- define "avalanche.injectorWorkers" -}}
 {{- $override := .Values.injector.config.workers | default 0 -}}
 {{- if gt ($override | int) 0 -}}
-{{- $override -}}
+{{- $override | int -}}
 {{- else -}}
-{{- index .Values.presets .Values.sizingPreset "injector" "workers" -}}
+{{- $preset := include "avalanche.presetComponent" (dict "ctx" . "component" "injector") | fromYaml -}}
+{{- $preset.workers | int -}}
 {{- end -}}
+{{- end }}
+
+{{/*
+Look up a component's block in the active sizing preset, returned as YAML
+(callers pipe through fromYaml). Fails fast with a clear, actionable message
+if the sizingPreset name — or the component within it — is unknown, instead of
+a nil dereference deep in a template.
+*/}}
+{{- define "avalanche.presetComponent" -}}
+{{- $ctx := .ctx -}}
+{{- $component := .component -}}
+{{- $preset := index $ctx.Values.presets $ctx.Values.sizingPreset -}}
+{{- if not $preset -}}
+{{- fail (printf "avalanche: unknown sizingPreset %q — valid presets: %s" $ctx.Values.sizingPreset (keys $ctx.Values.presets | sortAlpha | join ", ")) -}}
+{{- end -}}
+{{- $block := index $preset $component -}}
+{{- if not $block -}}
+{{- fail (printf "avalanche: sizingPreset %q has no entry for component %q" $ctx.Values.sizingPreset $component) -}}
+{{- end -}}
+{{- toYaml $block -}}
 {{- end }}
 
 {{/*

--- a/charts/avalanche/templates/adjudicator-deployment.yaml
+++ b/charts/avalanche/templates/adjudicator-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "snowplow.labels" . | nindent 4 }}
     app.kubernetes.io/component: validation
 spec:
-  replicas: {{ .Values.adjudicator.replicas }}
+  replicas: {{ include "avalanche.componentReplicas" (dict "ctx" . "component" "adjudicator") }}
   selector:
     matchLabels:
       {{- include "avalanche.selectorLabels" . | nindent 6 }}
@@ -85,7 +85,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
           resources:
-            {{- toYaml .Values.adjudicator.resources | nindent 12 }}
+            {{- include "avalanche.componentResources" (dict "ctx" . "component" "adjudicator") | nindent 12 }}
       volumes:
         - name: config
           configMap:

--- a/charts/avalanche/templates/aggregator-deployment.yaml
+++ b/charts/avalanche/templates/aggregator-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "snowplow.labels" . | nindent 4 }}
     app.kubernetes.io/component: aggregator
 spec:
-  replicas: {{ .Values.aggregator.replicas }}
+  replicas: {{ include "avalanche.componentReplicas" (dict "ctx" . "component" "aggregator") }}
   selector:
     matchLabels:
       {{- include "avalanche.selectorLabels" . | nindent 6 }}
@@ -81,7 +81,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
           resources:
-            {{- toYaml .Values.aggregator.resources | nindent 12 }}
+            {{- include "avalanche.componentResources" (dict "ctx" . "component" "aggregator") | nindent 12 }}
       volumes:
         - name: config
           configMap:

--- a/charts/avalanche/templates/aggregator-kubernetes-deployment.yaml
+++ b/charts/avalanche/templates/aggregator-kubernetes-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "snowplow.labels" . | nindent 4 }}
     app.kubernetes.io/component: aggregator-kubernetes
 spec:
-  replicas: {{ .Values.aggregatorKubernetes.replicas }}
+  replicas: {{ include "avalanche.componentReplicas" (dict "ctx" . "component" "aggregatorKubernetes") }}
   selector:
     matchLabels:
       {{- include "avalanche.selectorLabels" . | nindent 6 }}
@@ -79,7 +79,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
           resources:
-            {{- toYaml .Values.aggregatorKubernetes.resources | nindent 12 }}
+            {{- include "avalanche.componentResources" (dict "ctx" . "component" "aggregatorKubernetes") | nindent 12 }}
       volumes:
         - name: config
           configMap:

--- a/charts/avalanche/templates/configmap.yaml
+++ b/charts/avalanche/templates/configmap.yaml
@@ -27,9 +27,7 @@ data:
       {{- if .Values.injector.config.protocol }}
       protocol: {{ .Values.injector.config.protocol | quote }}
       {{- end }}
-      {{- if .Values.injector.config.workers }}
-      workers: {{ .Values.injector.config.workers }}
-      {{- end }}
+      workers: {{ include "avalanche.injectorWorkers" . }}
       {{- if .Values.injector.config.timeout }}
       timeout: {{ .Values.injector.config.timeout | quote }}
       {{- end }}

--- a/charts/avalanche/templates/controller-deployment.yaml
+++ b/charts/avalanche/templates/controller-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "snowplow.labels" . | nindent 4 }}
     app.kubernetes.io/component: orchestration
 spec:
-  replicas: {{ .Values.controller.replicas }}
+  replicas: {{ include "avalanche.componentReplicas" (dict "ctx" . "component" "controller") }}
   selector:
     matchLabels:
       {{- include "avalanche.selectorLabels" . | nindent 6 }}
@@ -80,7 +80,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
           resources:
-            {{- toYaml .Values.controller.resources | nindent 12 }}
+            {{- include "avalanche.componentResources" (dict "ctx" . "component" "controller") | nindent 12 }}
       volumes:
         - name: config
           configMap:

--- a/charts/avalanche/templates/correlator-deployment.yaml
+++ b/charts/avalanche/templates/correlator-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "snowplow.labels" . | nindent 4 }}
     app.kubernetes.io/component: correlation
 spec:
-  replicas: {{ .Values.correlator.replicas }}
+  replicas: {{ include "avalanche.componentReplicas" (dict "ctx" . "component" "correlator") }}
   selector:
     matchLabels:
       {{- include "avalanche.selectorLabels" . | nindent 6 }}
@@ -89,7 +89,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
           resources:
-            {{- toYaml .Values.correlator.resources | nindent 12 }}
+            {{- include "avalanche.componentResources" (dict "ctx" . "component" "correlator") | nindent 12 }}
       volumes:
         - name: config
           configMap:

--- a/charts/avalanche/templates/injector-deployment.yaml
+++ b/charts/avalanche/templates/injector-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "snowplow.labels" . | nindent 4 }}
     app.kubernetes.io/component: load-generator
 spec:
-  replicas: {{ .Values.injector.replicas }}
+  replicas: {{ include "avalanche.componentReplicas" (dict "ctx" . "component" "injector") }}
   selector:
     matchLabels:
       {{- include "avalanche.selectorLabels" . | nindent 6 }}
@@ -91,7 +91,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
           resources:
-            {{- toYaml .Values.injector.resources | nindent 12 }}
+            {{- include "avalanche.componentResources" (dict "ctx" . "component" "injector") | nindent 12 }}
       volumes:
         - name: config
           configMap:

--- a/charts/avalanche/templates/nats-deployment.yaml
+++ b/charts/avalanche/templates/nats-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "snowplow.labels" . | nindent 4 }}
     app.kubernetes.io/component: messaging
 spec:
-  replicas: {{ .Values.nats.replicas }}
+  replicas: {{ include "avalanche.componentReplicas" (dict "ctx" . "component" "nats") }}
   selector:
     matchLabels:
       {{- include "avalanche.selectorLabels" . | nindent 6 }}
@@ -51,5 +51,5 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 3
           resources:
-            {{- toYaml .Values.nats.resources | nindent 12 }}
+            {{- include "avalanche.componentResources" (dict "ctx" . "component" "nats") | nindent 12 }}
 {{- end }}

--- a/charts/avalanche/templates/observer-deployment.yaml
+++ b/charts/avalanche/templates/observer-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "snowplow.labels" . | nindent 4 }}
     app.kubernetes.io/component: monitoring
 spec:
-  replicas: {{ .Values.observer.replicas }}
+  replicas: {{ include "avalanche.componentReplicas" (dict "ctx" . "component" "observer") }}
   selector:
     matchLabels:
       {{- include "avalanche.selectorLabels" . | nindent 6 }}
@@ -81,7 +81,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
           resources:
-            {{- toYaml .Values.observer.resources | nindent 12 }}
+            {{- include "avalanche.componentResources" (dict "ctx" . "component" "observer") | nindent 12 }}
       volumes:
         - name: config
           configMap:

--- a/charts/avalanche/templates/observer-kubernetes-deployment.yaml
+++ b/charts/avalanche/templates/observer-kubernetes-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- include "snowplow.labels" . | nindent 4 }}
     app.kubernetes.io/component: observer-kubernetes-api
 spec:
-  replicas: {{ .Values.observerKubernetes.replicas }}
+  replicas: {{ include "avalanche.componentReplicas" (dict "ctx" . "component" "observerKubernetes") }}
   selector:
     matchLabels:
       {{- include "avalanche.selectorLabels" . | nindent 6 }}
@@ -72,7 +72,8 @@ spec:
               mountPath: /configs
               readOnly: true
           resources:
-            {{- toYaml .Values.observerKubernetes.resources | nindent 12 }}
+            {{- include "avalanche.componentResources" (dict "ctx" . "component" "observerKubernetes") | nindent 12 }}
+          # Liveness probe - check NATS health endpoint (consistent with other components)
           livenessProbe:
             exec:
               command:
@@ -110,7 +111,7 @@ metadata:
     {{- include "snowplow.labels" . | nindent 4 }}
     app.kubernetes.io/component: observer-kubernetes-cloudwatch
 spec:
-  replicas: {{ .Values.observerKubernetes.replicas }}
+  replicas: {{ include "avalanche.componentReplicas" (dict "ctx" . "component" "observerKubernetes") }}
   selector:
     matchLabels:
       {{- include "avalanche.selectorLabels" . | nindent 6 }}
@@ -168,7 +169,7 @@ spec:
               mountPath: /configs
               readOnly: true
           resources:
-            {{- toYaml .Values.observerKubernetes.resources | nindent 12 }}
+            {{- include "avalanche.componentResources" (dict "ctx" . "component" "observerKubernetes") | nindent 12 }}
           livenessProbe:
             exec:
               command:

--- a/charts/avalanche/values.yaml
+++ b/charts/avalanche/values.yaml
@@ -71,11 +71,6 @@ presets:
       resources:
         requests: { cpu: "100m", memory: "64Mi" }
         limits:   { cpu: "500m", memory: "256Mi" }
-    mockTarget:
-      replicas: 1
-      resources:
-        requests: { cpu: "100m", memory: "64Mi" }
-        limits:   { cpu: "500m", memory: "256Mi" }
     nats:
       replicas: 1
       resources:
@@ -124,11 +119,6 @@ presets:
       resources:
         requests: { cpu: "100m", memory: "128Mi" }
         limits:   { cpu: "500m", memory: "256Mi" }
-    mockTarget:
-      replicas: 1
-      resources:
-        requests: { cpu: "200m", memory: "128Mi" }
-        limits:   { cpu: "1000m", memory: "512Mi" }
     nats:
       replicas: 1
       resources:
@@ -182,11 +172,6 @@ presets:
       resources:
         requests: { cpu: "200m", memory: "256Mi" }
         limits:   { cpu: "1000m", memory: "512Mi" }
-    mockTarget:
-      replicas: 1
-      resources:
-        requests: { cpu: "500m", memory: "256Mi" }
-        limits:   { cpu: "2000m", memory: "1Gi" }
     nats:
       replicas: 1
       resources:

--- a/charts/avalanche/values.yaml
+++ b/charts/avalanche/values.yaml
@@ -23,7 +23,7 @@ legacyMode: true
 #
 #   small  — smoke tests, kind/docker-desktop  (~100 RPS injector ceiling)
 #   medium — sustained multi-k RPS             (~2000 RPS target — default)
-#   large  — high-throughput perf baselines    (3 injector replicas)
+#   large  — high-throughput perf baselines    (1 injector @ 4 CPU / 100 workers)
 sizingPreset: medium  # small | medium | large
 
 # Sizing presets — see ticket QA-780 for the rationale behind these values.

--- a/charts/avalanche/values.yaml
+++ b/charts/avalanche/values.yaml
@@ -15,6 +15,184 @@ global:
 # The ConfigMap content is unchanged either way; only the deployment args/env differ.
 legacyMode: true
 
+# Sizing preset. Selects per-component CPU/memory/replicas/workers defaults from
+# the `presets:` map below.
+#
+# Per-component overrides (`<component>.replicas`, `<component>.resources`,
+# `injector.config.workers`) win when set to a non-zero/non-empty value.
+#
+#   small  — smoke tests, kind/docker-desktop  (~100 RPS injector ceiling)
+#   medium — sustained multi-k RPS             (~2000 RPS target — default)
+#   large  — high-throughput perf baselines    (3 injector replicas)
+sizingPreset: medium  # small | medium | large
+
+# Sizing presets — see ticket QA-780 for the rationale behind these values.
+# Add a new preset by adding a top-level key here and pointing `sizingPreset` at it.
+presets:
+  small:
+    injector:
+      replicas: 1
+      workers: 3
+      resources:
+        requests: { cpu: "100m", memory: "64Mi" }
+        limits:   { cpu: "500m", memory: "256Mi" }
+    observer:
+      replicas: 1
+      resources:
+        requests: { cpu: "100m", memory: "64Mi" }
+        limits:   { cpu: "500m", memory: "256Mi" }
+    correlator:
+      replicas: 1
+      resources:
+        requests: { cpu: "100m", memory: "128Mi" }
+        limits:   { cpu: "500m", memory: "512Mi" }
+    adjudicator:
+      replicas: 1
+      resources:
+        requests: { cpu: "100m", memory: "64Mi" }
+        limits:   { cpu: "500m", memory: "256Mi" }
+    controller:
+      replicas: 1
+      resources:
+        requests: { cpu: "100m", memory: "128Mi" }
+        limits:   { cpu: "500m", memory: "512Mi" }
+    aggregator:
+      replicas: 1
+      resources:
+        requests: { cpu: "100m", memory: "64Mi" }
+        limits:   { cpu: "500m", memory: "256Mi" }
+    aggregatorKubernetes:
+      replicas: 1
+      resources:
+        requests: { cpu: "100m", memory: "64Mi" }
+        limits:   { cpu: "500m", memory: "256Mi" }
+    observerKubernetes:
+      replicas: 1
+      resources:
+        requests: { cpu: "100m", memory: "64Mi" }
+        limits:   { cpu: "500m", memory: "256Mi" }
+    mockTarget:
+      replicas: 1
+      resources:
+        requests: { cpu: "100m", memory: "64Mi" }
+        limits:   { cpu: "500m", memory: "256Mi" }
+    nats:
+      replicas: 1
+      resources:
+        requests: { cpu: "100m", memory: "64Mi" }
+        limits:   { cpu: "500m", memory: "256Mi" }
+
+  medium:
+    injector:
+      replicas: 1
+      workers: 50
+      resources:
+        requests: { cpu: "500m", memory: "512Mi" }
+        limits:   { cpu: "2000m", memory: "2Gi" }
+    observer:
+      replicas: 1
+      resources:
+        requests: { cpu: "200m", memory: "256Mi" }
+        limits:   { cpu: "1000m", memory: "1Gi" }
+    correlator:
+      replicas: 1
+      resources:
+        requests: { cpu: "200m", memory: "256Mi" }
+        limits:   { cpu: "1000m", memory: "1Gi" }
+    adjudicator:
+      replicas: 1
+      resources:
+        requests: { cpu: "200m", memory: "128Mi" }
+        limits:   { cpu: "1000m", memory: "512Mi" }
+    controller:
+      replicas: 1
+      resources:
+        requests: { cpu: "200m", memory: "256Mi" }
+        limits:   { cpu: "1000m", memory: "1Gi" }
+    aggregator:
+      replicas: 1
+      resources:
+        requests: { cpu: "200m", memory: "128Mi" }
+        limits:   { cpu: "1000m", memory: "512Mi" }
+    aggregatorKubernetes:
+      replicas: 1
+      resources:
+        requests: { cpu: "100m", memory: "128Mi" }
+        limits:   { cpu: "500m", memory: "256Mi" }
+    observerKubernetes:
+      replicas: 1
+      resources:
+        requests: { cpu: "100m", memory: "128Mi" }
+        limits:   { cpu: "500m", memory: "256Mi" }
+    mockTarget:
+      replicas: 1
+      resources:
+        requests: { cpu: "200m", memory: "128Mi" }
+        limits:   { cpu: "1000m", memory: "512Mi" }
+    nats:
+      replicas: 1
+      resources:
+        requests: { cpu: "200m", memory: "256Mi" }
+        limits:   { cpu: "1000m", memory: "1Gi" }
+
+  large:
+    injector:
+      # Multi-replica injector wiring is not yet supported by the controller —
+      # all replicas would receive the same per-injector RPS via NATS pub/sub
+      # and inject in parallel, multiplying total RPS by the replica count.
+      # Tracked separately as a scaling task; pinned to 1 across all presets
+      # for now. Differentiate via CPU/memory/workers per pod instead.
+      replicas: 1
+      workers: 100
+      resources:
+        requests: { cpu: "1000m", memory: "1Gi" }
+        limits:   { cpu: "4000m", memory: "4Gi" }
+    observer:
+      replicas: 1
+      resources:
+        requests: { cpu: "500m", memory: "512Mi" }
+        limits:   { cpu: "2000m", memory: "2Gi" }
+    correlator:
+      replicas: 1
+      resources:
+        requests: { cpu: "500m", memory: "512Mi" }
+        limits:   { cpu: "2000m", memory: "2Gi" }
+    adjudicator:
+      replicas: 1
+      resources:
+        requests: { cpu: "500m", memory: "256Mi" }
+        limits:   { cpu: "2000m", memory: "1Gi" }
+    controller:
+      replicas: 1
+      resources:
+        requests: { cpu: "500m", memory: "512Mi" }
+        limits:   { cpu: "2000m", memory: "2Gi" }
+    aggregator:
+      replicas: 1
+      resources:
+        requests: { cpu: "500m", memory: "256Mi" }
+        limits:   { cpu: "2000m", memory: "1Gi" }
+    aggregatorKubernetes:
+      replicas: 1
+      resources:
+        requests: { cpu: "200m", memory: "256Mi" }
+        limits:   { cpu: "1000m", memory: "512Mi" }
+    observerKubernetes:
+      replicas: 1
+      resources:
+        requests: { cpu: "200m", memory: "256Mi" }
+        limits:   { cpu: "1000m", memory: "512Mi" }
+    mockTarget:
+      replicas: 1
+      resources:
+        requests: { cpu: "500m", memory: "256Mi" }
+        limits:   { cpu: "2000m", memory: "1Gi" }
+    nats:
+      replicas: 1
+      resources:
+        requests: { cpu: "500m", memory: "512Mi" }
+        limits:   { cpu: "2000m", memory: "2Gi" }
+
 # Cloud service account configuration (OIDC-based IAM integration)
 cloudserviceaccount:
   # Whether to create a service-account
@@ -63,14 +241,10 @@ nats:
     repository: nats
     tag: "2.10-alpine"
     pullPolicy: IfNotPresent
-  replicas: 1
-  resources:
-    requests:
-      memory: "64Mi"
-      cpu: "100m"
-    limits:
-      memory: "256Mi"
-      cpu: "500m"
+  # 0 = inherit from sizingPreset; set to a non-zero value to override.
+  replicas: 0
+  # {} = inherit from sizingPreset; set requests/limits to override.
+  resources: {}
   service:
     type: ClusterIP
     clientPort: 4222
@@ -82,7 +256,8 @@ injector:
   image:
     repository: avalanche-injector-private
     tag: latest
-  replicas: 1
+  # 0 = inherit from sizingPreset; set to a non-zero value to override.
+  replicas: 0
   componentId: "k8s-injector"
   config:
     type: "http"
@@ -90,7 +265,8 @@ injector:
     endpoint: "http://host.docker.internal:8085"
     # Protocol for HTTP injector type (not used by snowplow type).
     protocol: "http"
-    workers: 3
+    # 0 = inherit from sizingPreset; set to a non-zero value to override.
+    workers: 0
     timeout: "5s"
     # Skip TLS certificate verification (useful for testing with self-signed certs)
     insecureSkipVerify: false
@@ -98,13 +274,8 @@ injector:
     # generator:
     #   preset: "typical-web"
     #   seed: 0
-  resources:
-    requests:
-      memory: "64Mi"
-      cpu: "100m"
-    limits:
-      memory: "256Mi"
-      cpu: "500m"
+  # {} = inherit from sizingPreset; set requests/limits to override.
+  resources: {}
 
 # Observer configuration
 observer:
@@ -112,7 +283,8 @@ observer:
   image:
     repository: avalanche-observer-private
     tag: latest
-  replicas: 1
+  # 0 = inherit from sizingPreset; set to a non-zero value to override.
+  replicas: 0
   componentId: "k8s-observer"
   config:
     type: "mockserver"
@@ -123,13 +295,8 @@ observer:
     # For snowplow-kinesis observer type:
     # streamArn: ""  # AWS Kinesis stream ARN
     # region: ""     # AWS region
-  resources:
-    requests:
-      memory: "64Mi"
-      cpu: "100m"
-    limits:
-      memory: "256Mi"
-      cpu: "500m"
+  # {} = inherit from sizingPreset; set requests/limits to override.
+  resources: {}
 
 # Mock Target configuration (self-contained testing without external collector)
 mockTarget:
@@ -153,7 +320,8 @@ correlator:
   image:
     repository: avalanche-correlator-private
     tag: latest
-  replicas: 1
+  # 0 = inherit from sizingPreset; set to a non-zero value to override.
+  replicas: 0
   componentId: "k8s-correlator"
   # Metrics write interval in seconds (how often to write aggregated stats to database)
   # Lower values give more granular data but increase database load
@@ -168,13 +336,8 @@ correlator:
   service:
     type: ClusterIP
     port: 8090
-  resources:
-    requests:
-      memory: "128Mi"
-      cpu: "100m"
-    limits:
-      memory: "512Mi"
-      cpu: "500m"
+  # {} = inherit from sizingPreset; set requests/limits to override.
+  resources: {}
 
 # Adjudicator configuration
 adjudicator:
@@ -182,7 +345,8 @@ adjudicator:
   image:
     repository: avalanche-adjudicator-private
     tag: latest
-  replicas: 1
+  # 0 = inherit from sizingPreset; set to a non-zero value to override.
+  replicas: 0
   componentId: "k8s-adjudicator"
   config:
     type: "adjudicator"
@@ -195,13 +359,8 @@ adjudicator:
     default: |
       // Default validation rule
       correlation_rate >= 0.95 && error_rate <= 0.05
-  resources:
-    requests:
-      memory: "64Mi"
-      cpu: "100m"
-    limits:
-      memory: "256Mi"
-      cpu: "500m"
+  # {} = inherit from sizingPreset; set requests/limits to override.
+  resources: {}
 
 # Controller configuration
 controller:
@@ -209,7 +368,8 @@ controller:
   image:
     repository: avalanche-controller-private
     tag: latest
-  replicas: 1
+  # 0 = inherit from sizingPreset; set to a non-zero value to override.
+  replicas: 0
   componentId: "k8s-controller"
   apiPort: 8080
   config:
@@ -236,13 +396,8 @@ controller:
     pathType: Prefix
     # TLS secret name (defaults to {hostname-with-dashes}-tls)
     tlsSecretName: ""
-  resources:
-    requests:
-      memory: "128Mi"
-      cpu: "100m"
-    limits:
-      memory: "512Mi"
-      cpu: "500m"
+  # {} = inherit from sizingPreset; set requests/limits to override.
+  resources: {}
 
 # Aggregator configuration (injection timing metrics)
 aggregator:
@@ -250,7 +405,8 @@ aggregator:
   image:
     repository: avalanche-aggregator-private
     tag: latest
-  replicas: 1
+  # 0 = inherit from sizingPreset; set to a non-zero value to override.
+  replicas: 0
   componentId: "k8s-aggregator"
   config:
     type: "metrics-aggregator"
@@ -279,13 +435,8 @@ aggregator:
         - p50
         - p95
         - max
-  resources:
-    requests:
-      memory: "64Mi"
-      cpu: "100m"
-    limits:
-      memory: "256Mi"
-      cpu: "500m"
+  # {} = inherit from sizingPreset; set requests/limits to override.
+  resources: {}
 
 # Kubernetes Monitoring Aggregator configuration (Phase 12.3)
 # Aggregates kubernetes_monitoring metrics into window/phase/run statistics
@@ -294,7 +445,8 @@ aggregatorKubernetes:
   image:
     repository: avalanche-aggregator-private
     tag: latest
-  replicas: 1
+  # 0 = inherit from sizingPreset; set to a non-zero value to override.
+  replicas: 0
   componentId: "kubernetes-aggregator"
   config:
     type: "metrics-aggregator"
@@ -385,13 +537,8 @@ aggregatorKubernetes:
         - last
         - max
         - sum
-  resources:
-    requests:
-      memory: "64Mi"
-      cpu: "100m"
-    limits:
-      memory: "256Mi"
-      cpu: "500m"
+  # {} = inherit from sizingPreset; set requests/limits to override.
+  resources: {}
 
 # Kinesis Stream Aggregator configuration (QA-827 Phase 2)
 # Aggregates kinesis_stream_monitoring per-stream rows into (stream × phase)
@@ -525,7 +672,8 @@ observerKubernetes:
   image:
     repository: avalanche-observer-private
     tag: kubernetes
-  replicas: 1
+  # 0 = inherit from sizingPreset; set to a non-zero value to override.
+  replicas: 0
   # When both observers run, the cloudwatch observer's componentId is suffixed
   # with "-cloudwatch"; the api observer keeps the base value below (for
   # backwards compatibility with existing test plans that reference
@@ -563,13 +711,8 @@ observerKubernetes:
     # cloudserviceaccount is deployed, observer-kubernetes reuses it and inherits
     # its IRSA role instead, so this field is not used in that case.
     iamRoleArn: ""
-  resources:
-    requests:
-      memory: "64Mi"
-      cpu: "100m"
-    limits:
-      memory: "256Mi"
-      cpu: "500m"
+  # {} = inherit from sizingPreset; set requests/limits to override.
+  resources: {}
 
 # Logging configuration
 logging:


### PR DESCRIPTION
## What
Adds a top-level `sizingPreset: small | medium | large` (default `medium`) to the avalanche chart, backed by a `presets:` map and resolved per-component via `_helpers.tpl` (`componentResources` / `componentReplicas` / `injectorWorkers`). Per-component `resources` / `replicas` / `injector.config.workers` overrides still win. Chart **0.6.5 → 0.7.0**.

Replaces the old demo-sized defaults that OOMKill the load generator above ~100–200 RPS, so a default install can sustain real load.

## Why
[QA-780]. Cut fresh off current `main` (post-#337, which brought the chart to 0.6.5).

## Validation
This is the same chart already published and exercised as **qa-helm-charts 0.7.0**:
- `helm lint` clean; all three presets render; per-component override precedence verified.
- Real-EKS: default `helm install` healthy; and with the `large` preset a single injector sustained **~2,221 RPS** against a healthy collector (100% correlation, P99 270 ms) — clearing the QA-780 ≥2000 RPS target.

## Notes
- `mockTarget` and `aggregatorKinesisStream` keep literal resources (not preset-driven) — minor, flagged in QA-780.
- Brings the canonical published chart in line with qa-helm-charts; the embedded `avalanche/helm` copy is being removed under QA-1109 (→ single source of truth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[QA-780]: https://snplow.atlassian.net/browse/QA-780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ