### PR TITLE
[TECOPS-17701] Update GitHub Actions addons to Node 24 runtime

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -7,38 +7,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v5
         with:
           version: v3.8.1
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v6
         with:
-          python-version: 3.8
+          python-version: '3.13'
 
       - name: Add self
         run: helm repo add snowplow-devops https://snowplow-devops.github.io/helm-charts
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@v2.8.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
           changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)
         run: ct lint --target-branch ${{ github.event.repository.default_branch }} --config ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.8.0
+        uses: helm/kind-action@v1.14.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -22,7 +22,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v5
         with:
           version: v3.8.1
 
@@ -30,6 +30,6 @@ jobs:
         run: helm repo add snowplow-devops https://snowplow-devops.github.io/helm-charts
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.0
+        uses: helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### Jira reference(s)
[TECOPS-17701](https://snplow.atlassian.net/browse/TECOPS-17701)

### Overview
GitHub is deprecating the Node 20 runtime for JavaScript actions in 2026. The workflows in this repo pin several actions to old majors (some still on Node 16/20), which now emit deprecation warnings. This bumps each action to a major that runs on the **Node 24** runtime, and clears the related deprecated `::set-output` workflow command.

### Changes included
**`.github/workflows/lint-test.yml`**
- `actions/checkout` `v2` → `v6` (Node 24)
- `azure/setup-helm` `v1` → `v5` (Node 24)
- `actions/setup-python` `v2` → `v6` (Node 24); `python-version` `3.8` → `3.13` — Python 3.8 is EOL and is no longer provisionable on current `ubuntu-latest` runners by the new setup-python
- `helm/chart-testing-action` `v2.6.1` → `v2.8.0`
- `helm/kind-action` `v1.8.0` → `v1.14.0` (Node 24)
- Replaced deprecated `::set-output name=changed::true` with `echo "changed=true" >> "$GITHUB_OUTPUT"`

**`.github/workflows/release.yml`**
- `actions/checkout` `v2` → `v6` (Node 24)
- `azure/setup-helm` `v1` → `v5` (Node 24)
- `helm/chart-releaser-action` `v1.4.0` → `v1.7.0`

`helm/chart-testing-action` and `helm/chart-releaser-action` are composite actions (no Node runtime of their own) — bumped for currency, not for the Node deprecation.

### Testing results
Verified each target version's `action.yml` declares `using: node24` (checkout, setup-python, setup-helm, kind-action). The `lint-test` workflow runs on PRs, so this PR itself exercises the updated lint/test path; `release` runs on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECOPS-17701]: https://snplow.atlassian.net/browse/TECOPS-17701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ