### PR TITLE
Add tolerations to daemonset and aws-otel-collector charts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Version 0.3.42 (2026-07-02)
+---------------------------
+charts/daemonset-0.6.0: Add tolerations (default `- operator: Exists`), nodeSelector and affinity so the daemonset schedules onto every node, including tainted / Karpenter-provisioned nodes. Set tolerations to [] to revert to default scheduling.
+charts/aws-otel-collector-0.15.0: Add tolerations (default `- operator: Exists`), nodeSelector and affinity so the collector schedules onto every node, including tainted / Karpenter-provisioned nodes. Set tolerations to [] to revert to default scheduling.
+
 Version 0.3.41 (2026-06-11)
 ---------------------------
 charts/avalanche-0.7.0: Add sizing presets (small/medium/large) for resource defaults. New top-level sizingPreset (default medium) backed by a presets map, resolved per-component via _helpers.tpl (componentResources / componentReplicas / injectorWorkers); per-component resources/replicas/workers overrides still win. Lets a default install sustain real load instead of the old demo-sized defaults.

--- a/charts/aws-otel-collector/Chart.yaml
+++ b/charts/aws-otel-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-otel-collector
 description: A Helm chart to deploy aws-otel-collector project
-version: 0.14.0
+version: 0.15.0
 appVersion: "v0.48.0"
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts

--- a/charts/aws-otel-collector/README.md
+++ b/charts/aws-otel-collector/README.md
@@ -52,6 +52,9 @@ helm delete aws-otel-collector --namespace kube-system
 | resources.limits.memory | string | `"200Mi"` |  |
 | resources.requests.cpu | string | `"20m"` |  |
 | resources.requests.memory | string | `"100Mi"` |  |
+| tolerations | list | `[{"operator":"Exists"}]` | Tolerations for the collector pods. Defaults to tolerating all taints so the collector is scheduled onto every node in the cluster, including tainted nodes (e.g. Karpenter-provisioned nodes). Set to [] to disable and use default scheduling. |
+| nodeSelector | object | `{}` | Node selector for constraining the collector to specific nodes |
+| affinity | object | `{}` | Affinity rules for the collector pods |
 | serviceAccount.create | bool | `true` | Whether to create a service account or not |
 | serviceAccount.name | string | `""` | The name of the service account to create or use |
 | serviceAccount.annotations | object | `{}` | Optional annotations to be applied to service account |

--- a/charts/aws-otel-collector/templates/daemonset.yaml
+++ b/charts/aws-otel-collector/templates/daemonset.yaml
@@ -16,6 +16,18 @@ spec:
         {{- include "aws-otel-collector.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "aws-otel-collector.serviceAccountName" . }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Release.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/aws-otel-collector/values.yaml
+++ b/charts/aws-otel-collector/values.yaml
@@ -33,6 +33,18 @@ resources:
     cpu: 20m
     memory: 100Mi
 
+# -- Tolerations for the collector pods. Defaults to tolerating all taints so the
+# collector is scheduled onto every node in the cluster, including tainted nodes
+# (e.g. Karpenter-provisioned nodes). Set to [] to disable and use default scheduling.
+tolerations:
+  - operator: Exists
+
+# -- Node selector for constraining the collector to specific nodes
+nodeSelector: {}
+
+# -- Affinity rules for the collector pods
+affinity: {}
+
 serviceAccount:
   # -- Whether to create a service account or not
   create: true

--- a/charts/daemonset/Chart.yaml
+++ b/charts/daemonset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: daemonset
 description: A Helm Chart to deploy an arbitrary container as a daemonset.
-version: 0.5.0
+version: 0.6.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:

--- a/charts/daemonset/README.md
+++ b/charts/daemonset/README.md
@@ -70,6 +70,9 @@ helm delete daemonset
 | hostPaths | list | `[]` | List of host paths to mount to the deployment |
 | resources | object | `{}` | Map of resource constraints for the service |
 | terminationGracePeriodSeconds | int | `60` | Grace period for termination of the service |
+| tolerations | list | `[{"operator":"Exists"}]` | Tolerations for the daemonset pods. Defaults to tolerating all taints so the daemonset is scheduled onto every node in the cluster, including tainted nodes (e.g. Karpenter-provisioned nodes). Set to [] to disable and use default scheduling. |
+| nodeSelector | object | `{}` | Node selector for constraining the daemonset to specific nodes |
+| affinity | object | `{}` | Affinity rules for the daemonset pods |
 | service.deploy | bool | `true` |  |
 | service.type | string | `"NodePort"` | Whether to setup service bindings |
 | service.name | string | `"http"` | Name of service |

--- a/charts/daemonset/templates/daemonset.yaml
+++ b/charts/daemonset/templates/daemonset.yaml
@@ -27,6 +27,19 @@ spec:
       hostNetwork: {{ .Values.config.hostNetworkAccess | default "false" }}
       dnsPolicy: {{ .Values.config.dnsPolicy | default "Default" }}
 
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
       {{- if .Values.cloudserviceaccount.deploy }}
       serviceAccountName: {{ .Values.cloudserviceaccount.name }}
       {{- end }}

--- a/charts/daemonset/values.yaml
+++ b/charts/daemonset/values.yaml
@@ -83,6 +83,18 @@ resources: {}
 # -- Grace period for termination of the service
 terminationGracePeriodSeconds: 60
 
+# -- Tolerations for the daemonset pods. Defaults to tolerating all taints so the
+# daemonset is scheduled onto every node in the cluster, including tainted nodes
+# (e.g. Karpenter-provisioned nodes). Set to [] to disable and use default scheduling.
+tolerations:
+  - operator: Exists
+
+# -- Node selector for constraining the daemonset to specific nodes
+nodeSelector: {}
+
+# -- Affinity rules for the daemonset pods
+affinity: {}
+
 service:
   deploy: true
   # -- Whether to setup service bindings


### PR DESCRIPTION
Default tolerations to `- operator: Exists` so both DaemonSets schedule onto every node, including tainted / Karpenter-provisioned nodes. Also expose nodeSelector and affinity.

- charts/daemonset 0.5.0 -> 0.6.0
- charts/aws-otel-collector 0.14.0 -> 0.15.0