### PR TITLE
[QA-1121] charts/avalanche 0.8.0: prometheus-jvm observer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.3.45 (2026-07-05)
+---------------------------
+charts/avalanche-0.8.0: Add the prometheus-jvm observer (observerPrometheus, disabled by default). New observer-prometheus Deployment, gated on observerPrometheus.enabled, that scrapes a Prometheus /metrics endpoint (e.g. Enrich's common-streams health-probe port) and records jvm_* series (heap / GC / threads / buffers) to the metrics backend for load-test analysis. New observer-prometheus.yaml (the pod's self-loaded config) and external-observer-prometheus.yaml (the external stub the test plan references for NATS phase coordination) configmap entries. A dedicated avalanche.observerPrometheus.serviceAccountName helper reuses the cloudserviceaccount SA (for the Timestream IRSA role) when deployed and otherwise falls back to the default SA (this observer needs no observer-kubernetes RBAC); AVALANCHE_INFLUXDB_TOKEN sources from the *-db-credentials secret when unset; replicas honours an explicit 0. (QA-1121, #344)
+
 Version 0.3.44 (2026-07-03)
 ---------------------------
 charts/cron-job-0.16.0: Add tolerations (default `- operator: Exists`) so cron job pods can be scheduled onto tainted / Karpenter-provisioned nodes. Set tolerations to [] to revert to default scheduling.

--- a/charts/avalanche/Chart.yaml
+++ b/charts/avalanche/Chart.yaml
@@ -3,7 +3,7 @@ name: avalanche
 description: A Helm chart for Avalanche - Progressive load testing framework for Snowplow infrastructure
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 type: application
-version: 0.7.0
+version: 0.8.0
 appVersion: "1.0.0"
 keywords:
   - avalanche

--- a/charts/avalanche/templates/_helpers.tpl
+++ b/charts/avalanche/templates/_helpers.tpl
@@ -41,6 +41,24 @@ creds are injected directly), use the component's own ServiceAccount.
 {{- end }}
 
 {{/*
+ServiceAccount name for the observer-prometheus pod.
+
+Unlike observer-kubernetes, this observer only scrapes an HTTP /metrics
+endpoint — it needs NO k8s API ClusterRole, only AWS credentials to write to
+Timestream. When cloudserviceaccount is deployed (e.g. DS4, IRSA), reuse that
+ServiceAccount so the pod inherits its Timestream IRSA role. When it is not
+deployed (sandbox/local, where AWS creds are injected directly), this returns
+empty so the Deployment falls back to the default ServiceAccount — it must NOT
+reuse the observer-kubernetes SA, which only exists when observerKubernetes is
+enabled (QA-1121).
+*/}}
+{{- define "avalanche.observerPrometheus.serviceAccountName" -}}
+{{- if .Values.cloudserviceaccount.deploy -}}
+{{- required "cloudserviceaccount.name is required when cloudserviceaccount.deploy is true (observer-prometheus reuses that ServiceAccount for its Timestream IRSA role)" .Values.cloudserviceaccount.name -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "avalanche.chart" -}}

--- a/charts/avalanche/templates/configmap.yaml
+++ b/charts/avalanche/templates/configmap.yaml
@@ -328,3 +328,37 @@ data:
   {{- end }}
 
   {{- end }}
+
+  # Prometheus JVM observer configs (QA-1121). observer-prometheus.yaml is the
+  # real config the pod self-loads via --config; external-observer-prometheus.yaml
+  # is the "external" stub the test plan references so the controller coordinates
+  # the (self-configured) pod over NATS for phase transitions.
+  {{- if .Values.observerPrometheus.enabled }}
+  observer-prometheus.yaml: |
+    type: {{ .Values.observerPrometheus.config.type | quote }}
+    name: {{ .Values.observerPrometheus.config.name | quote }}
+    config:
+      poll_interval: {{ .Values.observerPrometheus.config.pollInterval | quote }}
+      {{- if .Values.observerPrometheus.config.metricPrefixes }}
+      metric_prefixes:
+        {{- range .Values.observerPrometheus.config.metricPrefixes }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- end }}
+      targets:
+        {{- range .Values.observerPrometheus.config.targets }}
+        - url: {{ .url | quote }}
+          {{- if .role }}
+          role: {{ .role | quote }}
+          {{- end }}
+          {{- if .timeout }}
+          timeout: {{ .timeout | quote }}
+          {{- end }}
+        {{- end }}
+  external-observer-prometheus.yaml: |
+    type: "external"
+    name: {{ .Values.observerPrometheus.config.name | quote }}
+    config:
+      timeout: "30s"
+      underlying_type: "prometheus-jvm"
+  {{- end }}

--- a/charts/avalanche/templates/observer-prometheus-deployment.yaml
+++ b/charts/avalanche/templates/observer-prometheus-deployment.yaml
@@ -25,7 +25,10 @@ spec:
         {{- include "avalanche.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: observer-prometheus
     spec:
-      serviceAccountName: {{ include "avalanche.observerKubernetes.serviceAccountName" . }}
+      {{- $sa := include "avalanche.observerPrometheus.serviceAccountName" . }}
+      {{- if $sa }}
+      serviceAccountName: {{ $sa }}
+      {{- end }}
       imagePullSecrets:
       - name: {{ .Values.dockerconfigjson.name }}
       containers:

--- a/charts/avalanche/templates/observer-prometheus-deployment.yaml
+++ b/charts/avalanche/templates/observer-prometheus-deployment.yaml
@@ -1,0 +1,99 @@
+{{- if .Values.observerPrometheus.enabled }}
+# observer-prometheus (QA-1121): scrapes a Prometheus /metrics endpoint (e.g.
+# Enrich's health-probe port) and records the jvm_* series to the metrics DB.
+# Pure-Go HTTP scraper — no JMX. Reuses the cloudserviceaccount IRSA role (same
+# as observer-kubernetes) so it can write to Timestream. Self-configures from its
+# mounted config and connects to NATS for phase coordination.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "avalanche.fullname" . }}-observer-prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "snowplow.labels" . | nindent 4 }}
+    app.kubernetes.io/component: observer-prometheus
+spec:
+  replicas: {{ .Values.observerPrometheus.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "avalanche.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: observer-prometheus
+  template:
+    metadata:
+      labels:
+        {{- include "snowplow.labels" . | nindent 8 }}
+        {{- include "avalanche.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: observer-prometheus
+    spec:
+      serviceAccountName: {{ include "avalanche.observerKubernetes.serviceAccountName" . }}
+      imagePullSecrets:
+      - name: {{ .Values.dockerconfigjson.name }}
+      containers:
+        - name: observer-prometheus
+          image: {{ include "avalanche.image" (dict "images" .Values.images "image" .Values.observerPrometheus.image) }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          args:
+            - observer
+            - --config
+            - /configs/observer-prometheus.yaml
+          env:
+            - name: AVALANCHE_LOG_LEVEL
+              value: {{ .Values.images.logLevel | quote }}
+            - name: AVALANCHE_NATS_URL
+              value: "nats://{{ include "avalanche.fullname" . }}-nats:4222"
+            - name: AVALANCHE_COMPONENT_ID
+              value: {{ .Values.observerPrometheus.componentId | quote }}
+            # Database configuration
+            {{- if eq .Values.database.type "influxdb" }}
+            - name: AVALANCHE_DB_TYPE
+              value: "influxdb"
+            - name: AVALANCHE_INFLUXDB_URL
+              value: {{ .Values.database.influxdb.url | quote }}
+            - name: AVALANCHE_INFLUXDB_TOKEN
+              value: {{ .Values.database.influxdb.token | quote }}
+            - name: AVALANCHE_INFLUXDB_ORG
+              value: {{ .Values.database.influxdb.org | quote }}
+            - name: AVALANCHE_INFLUXDB_BUCKET
+              value: {{ .Values.database.influxdb.bucket | quote }}
+            {{- else if eq .Values.database.type "timestream" }}
+            - name: AVALANCHE_DB_TYPE
+              value: "timestream"
+            - name: AVALANCHE_TIMESTREAM_ENABLED
+              value: "true"
+            - name: AVALANCHE_TIMESTREAM_DATABASE
+              value: {{ .Values.database.timestream.database | quote }}
+            - name: AVALANCHE_TIMESTREAM_REGION
+              value: {{ .Values.database.timestream.region | quote }}
+            {{- end }}
+            {{- include "avalanche.awsEnv" . | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /configs
+              readOnly: true
+          {{- with .Values.observerPrometheus.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          # Liveness/readiness probe NATS health endpoint (consistent with other observers)
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - wget -q --spider http://{{ include "avalanche.fullname" . }}-nats:8222/healthz
+            initialDelaySeconds: 30
+            periodSeconds: 60
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - wget -q --spider http://{{ include "avalanche.fullname" . }}-nats:8222/healthz
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "avalanche.fullname" . }}-config
+{{- end }}

--- a/charts/avalanche/templates/observer-prometheus-deployment.yaml
+++ b/charts/avalanche/templates/observer-prometheus-deployment.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "snowplow.labels" . | nindent 4 }}
     app.kubernetes.io/component: observer-prometheus
 spec:
-  replicas: {{ .Values.observerPrometheus.replicas | default 1 }}
+  replicas: {{ .Values.observerPrometheus.replicas }}
   selector:
     matchLabels:
       {{- include "avalanche.selectorLabels" . | nindent 6 }}

--- a/charts/avalanche/templates/observer-prometheus-deployment.yaml
+++ b/charts/avalanche/templates/observer-prometheus-deployment.yaml
@@ -53,7 +53,15 @@ spec:
             - name: AVALANCHE_INFLUXDB_URL
               value: {{ .Values.database.influxdb.url | quote }}
             - name: AVALANCHE_INFLUXDB_TOKEN
+            {{- if .Values.database.influxdb.token }}
               value: {{ .Values.database.influxdb.token | quote }}
+            {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "avalanche.fullname" . }}-db-credentials
+                  key: influxdb-token
+                  optional: true
+            {{- end }}
             - name: AVALANCHE_INFLUXDB_ORG
               value: {{ .Values.database.influxdb.org | quote }}
             - name: AVALANCHE_INFLUXDB_BUCKET

--- a/charts/avalanche/values.yaml
+++ b/charts/avalanche/values.yaml
@@ -614,6 +614,42 @@ aws:
   # Local only: AWS session token (optional, for temporary credentials)
   sessionToken: ""
 
+# Prometheus JVM Observer configuration (QA-1121)
+# Scrapes a Prometheus /metrics endpoint (e.g. Enrich's health-probe port, which
+# serves /metrics when the common-streams Micrometer→Prometheus reporter is
+# enabled) and records the jvm_* series (heap / GC / threads) to the metrics DB.
+# Pure-Go HTTP scraper — no JMX. Writes to Timestream via the shared
+# cloudserviceaccount IRSA role (same as observerKubernetes), so
+# cloudserviceaccount.deploy must be true when enabled.
+observerPrometheus:
+  enabled: false
+  image:
+    repository: avalanche-observer-private
+    tag: latest
+  replicas: 1
+  componentId: "prometheus-jvm-observer"
+  config:
+    type: "prometheus-jvm"
+    name: "prometheus-jvm-observer"
+    pollInterval: "15s"
+    metricPrefixes:
+      - "jvm_"
+    # List of Prometheus /metrics endpoints to scrape. Each entry: url (required,
+    # absolute http(s) URL), role (optional identity tag), timeout (optional).
+    targets: []
+    # Example:
+    #   targets:
+    #     - url: "http://my-enrich.svc.cluster.local:8000/metrics"
+    #       role: "enrich"
+  # Preset-independent plain resource block (does not use sizingPreset).
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "256Mi"
+
 # Kubernetes Infrastructure Observer configuration (Phase 12.1 + QA-822)
 observerKubernetes:
   enabled: false  # master toggle — disabled by default; enable to monitor infra

--- a/charts/avalanche/values.yaml
+++ b/charts/avalanche/values.yaml
@@ -618,9 +618,10 @@ aws:
 # Scrapes a Prometheus /metrics endpoint (e.g. Enrich's health-probe port, which
 # serves /metrics when the common-streams Micrometer→Prometheus reporter is
 # enabled) and records the jvm_* series (heap / GC / threads) to the metrics DB.
-# Pure-Go HTTP scraper — no JMX. Writes to Timestream via the shared
-# cloudserviceaccount IRSA role (same as observerKubernetes), so
-# cloudserviceaccount.deploy must be true when enabled.
+# Pure-Go HTTP scraper — no JMX. For AWS auth to write metrics: when
+# cloudserviceaccount.deploy is true (e.g. DS4) the pod reuses that
+# ServiceAccount for its Timestream IRSA role; otherwise (sandbox/local) it
+# runs under the default ServiceAccount with AWS creds injected via aws.*.
 observerPrometheus:
   enabled: false
   image:


### PR DESCRIPTION
## What

Adds the `observerPrometheus` block to the avalanche chart (0.7.0 → **0.8.0**), which deploys avalanche's `prometheus-jvm` observer. The observer scrapes a Prometheus `/metrics` endpoint (e.g. Enrich's common-streams health-probe port 8000) and records `jvm_*` series (heap / GC / threads / buffers) to the metrics backend for load-test analysis.

Ported from the qa-helm-charts staging chart (QA-811 self-serve repo), where it was validated end-to-end against a real Enrich load test.

### Changes
- `values.yaml` — `observerPrometheus` config (disabled by default; image, poll interval, metric prefixes, scrape targets, resources)
- `templates/observer-prometheus-deployment.yaml` (new) — the observer Deployment, gated on `observerPrometheus.enabled`; reuses the `cloudserviceaccount` IRSA role for Timestream writes (same as `observerKubernetes`)
- `templates/configmap.yaml` — `observer-prometheus.yaml` (the pod's self-loaded `--config`) + `external-observer-prometheus.yaml` (the "external" stub the test plan references so the controller coordinates the self-configured pod over NATS for phase transitions)
- `Chart.yaml` — version 0.7.0 → 0.8.0

### Verified
- `helm lint` passes.
- `helm template` renders the observer Deployment + configmap entries when `observerPrometheus.enabled=true`, and is inert when disabled (the default), so existing consumers are unaffected.
- End-to-end: `TestAWSKinesisEnrichThroughputBaseline` (snowman) is green with this chart — 2,122 rows / 20 distinct JVM metrics land in the `jvm-monitoring` Timestream table, and all 5 JVM Grafana charts render.

### Related
- Avalanche observer + Grafana charts: snowplow-devops/avalanche2#22
- Follow-up once merged: bump snowman's `getAvalancheChartVersion()` default 0.7.0 → 0.8.0 so runs no longer need the `AVALANCHE_CHART_VERSION` / `AVALANCHE_HELM_REPOSITORY` overrides.

Draft pending the avalanche merge (so `:latest` observer image carries the JVM observer) and SRE review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)