### PR TITLE
charts/avalanche 0.12.1: correct the aggregator field-list comment (QA-1271)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.3.53 (2026-08-24)
+---------------------------
+charts/avalanche-0.12.1: Comment-only correction to the aggregatorKubernetes field whitelist. The percent-of-limit / percent-of-cluster entries claimed that including CloudWatch-only fields is "harmless (missing fields aggregate to zero)". That is not what the aggregator does: computeStats skips any field with no values and the Timestream source only populates a field when the column is non-NULL, so a field absent from every source row is omitted from the rollup entirely and a rule referencing it sees a missing field, not a zero. The old wording implied a guarantee that does not exist, and that false guarantee is what made rule guards of the form `<resource>_limit_* == 0.0 ||` look safe when they were in fact the mechanism by which those rules passed vacuously (a zero denominator short-circuited the rule to "passed" while asserting nothing). Also notes that QA-1271 added *_usage_percent_of_limit to the api-mode observer, so both observer paths now feed equivalent (entity x phase) rows. No template or default change: rendering the chart with the aggregators enabled produces output identical to 0.12.0 apart from the chart-version labels (helm.sh/chart, app.kubernetes.io/version), verified by diff. (QA-1271)
+
 Version 0.3.52 (2026-08-17)
 ---------------------------
 charts/service-deployment-0.42.0: Add buffering middleware support (#354)

--- a/charts/avalanche/Chart.yaml
+++ b/charts/avalanche/Chart.yaml
@@ -3,7 +3,7 @@ name: avalanche
 description: A Helm chart for Avalanche - Progressive load testing framework for Snowplow infrastructure
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 type: application
-version: 0.12.0
+version: 0.12.1
 appVersion: "1.0.0"
 keywords:
   - avalanche

--- a/charts/avalanche/values.yaml
+++ b/charts/avalanche/values.yaml
@@ -507,11 +507,20 @@ aggregatorKubernetes:
       error_event_count:
         - last
         - max
-      # CloudWatch-mode fields (QA-822). The CW observer writes percent-of-limit
-      # and percent-of-cluster fields; these aren't produced by the api-mode
-      # observer, but adding them to the aggregator's whitelist is harmless
-      # there (missing fields aggregate to zero) and makes both observer
-      # paths feed equivalent (entity × phase) rows.
+      # Percent-of-limit / percent-of-cluster fields (QA-822 CloudWatch; QA-1271
+      # added percent-of-limit to the api-mode observer too, so both observer
+      # paths now feed equivalent (entity × phase) rows and a rule written
+      # against a percentage works whichever source fed the row).
+      #
+      # QA-1271 correction: an absent field does NOT "aggregate to zero" as this
+      # comment used to claim. computeStats skips any field with no values
+      # (`len(values) == 0 -> continue`) and the Timestream source only populates
+      # a field when the column is non-NULL, so a field absent from every source
+      # row is OMITTED from the rollup entirely — no _mean/_last is emitted, and
+      # a rule referencing it sees a missing field rather than a zero. That is
+      # deliberate: it keeps "no limit configured" distinguishable from "a limit
+      # of zero", which is what made the old `_limit_* == 0.0 ||` rule guards
+      # pass vacuously.
       cpu_usage_percent_of_limit:
         - mean
         - max


### PR DESCRIPTION
Comment-only correction, patch bump. No behaviour change.

## What

The percent-of-limit / percent-of-cluster entries in `aggregatorKubernetes.config.fields` claimed that including CloudWatch-only fields is *"harmless (missing fields aggregate to zero)"*.

The aggregator does not do that:

- `pkg/aggregator/default.go` collects a field only when the source event has it (`if value, ok := event.NumericFields[...]; ok`), and `computeStats` skips any field with no values (`len(values) == 0 -> continue`).
- The Timestream source only populates a field when the column is non-NULL.

So a field absent from every source row is **omitted from the rollup entirely** — no `_mean`/`_last` is emitted — and a rule referencing it sees a missing field, not a zero.

## Why it matters

"Aggregates to zero" implied a guarantee that does not exist, and that false guarantee is what made acceptance-rule guards of the form `<resource>_limit_* == 0.0 ||` look like a safety property. They were in fact the mechanism by which those rules passed **vacuously**: an unconfigured limit was written as `0`, the rule divided by zero, the guard short-circuited it to "passed", and it asserted nothing while reporting `+Inf%`. Chasing that down was most of QA-1271.

The comment also now records that QA-1271 added `*_usage_percent_of_limit` to the api-mode observer, so both observer paths feed equivalent (entity × phase) rows and a rule written against a percentage works whichever source fed it.

## Verification

Rendered the chart with both aggregators enabled, before and after:

```
old (0.12.0): 1051 lines
new (0.12.1): 1051 lines
diff: only helm.sh/chart and app.kubernetes.io/version labels
      0 other differing lines
```

`helm lint` clean.

## Notes for reviewers

- **Patch, not minor** — comment-only.
- **No consumer bump.** snowman's `getAvalancheChartVersion()` stays pinned at `0.12.0`; there is nothing here for it to pick up.
- **Next functional change should use 0.14.0, not 0.13.0.** This repo's avalanche releases run 0.8.0 / 0.10.0 / 0.11.0 / 0.12.0, so 0.13.0 looks free here — but the `qa-helm-charts` staging fork already published an `avalanche-0.13.0` from a duplicate QA-1233 cut. Reusing it would put two different charts behind one version across the two repos.
- The same comment fix is on the staging fork (`qa-helm-charts`) so the two do not diverge on this line.

Refs QA-1271.