### PR TITLE
Add buffering middleware support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.3.52 (2026-08-17)
+---------------------------
+charts/service-deployment-0.42.0: Add buffering middleware support (#354)
+
 Version 0.3.51 (2026-07-31)
 ---------------------------
 charts/snowplow-iglu-server-0.19.0: Add optional service.ingress.<name>.tlsSecretName to use an existing TLS secret instead of the hardcoded {hostname}-tls, suppressing the cert-manager Certificate when set.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,10 @@ The repository uses ct.yaml for chart-testing configuration:
 4. Run chart-testing linter: `ct lint --charts charts/[chart-name]`
 5. Update `CHANGELOG` with version and changes
 
+### Maintainers
+- Keep the `maintainers` list in each chart's `Chart.yaml` sorted alphabetically by `name`.
+- After editing `maintainers`, regenerate the chart's `README.md` with `helm-docs` so its maintainers table stays in sync.
+
 ## File Structure Patterns
 
 ### Standard Chart Structure

--- a/charts/service-deployment/Chart.yaml
+++ b/charts/service-deployment/Chart.yaml
@@ -1,15 +1,21 @@
 apiVersion: v2
 name: service-deployment
 description: A Helm Chart to setup a generic deployment with optional service/hpa/vpa bindings
-version: 0.41.0
+version: 0.42.0
 icon: https://raw.githubusercontent.com/snowplow-devops/helm-charts/master/docs/logo/snowplow.png
 home: https://github.com/snowplow-devops/helm-charts
 sources:
   - https://github.com/snowplow-devops/helm-charts
 maintainers:
-  - name: jbeemster
-    url: https://github.com/jbeemster
-    email: jbeemster@users.noreply.github.com
+  - name: Andy-Hay
+    url: https://github.com/Andy-Hay
+    email: 3116331+Andy-Hay@users.noreply.github.com
+  - name: ianarsenault
+    url: https://github.com/ianarsenault
+    email: ianarsenault@users.noreply.github.com
+  - name: jamesarems
+    url: https://github.com/jamesarems
+    email: jamesarems@users.noreply.github.com
 keywords:
   - service
   - deployment

--- a/charts/service-deployment/README.md
+++ b/charts/service-deployment/README.md
@@ -1,6 +1,6 @@
 # service-deployment
 
-![Version: 0.41.0](https://img.shields.io/badge/Version-0.41.0-informational?style=flat-square)
+![Version: 0.42.0](https://img.shields.io/badge/Version-0.42.0-informational?style=flat-square)
 
 A Helm Chart to setup a generic deployment with optional service/hpa/vpa bindings
 
@@ -10,7 +10,9 @@ A Helm Chart to setup a generic deployment with optional service/hpa/vpa binding
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| jbeemster | <jbeemster@users.noreply.github.com> | <https://github.com/jbeemster> |
+| Andy-Hay | <3116331+Andy-Hay@users.noreply.github.com> | <https://github.com/Andy-Hay> |
+| ianarsenault | <ianarsenault@users.noreply.github.com> | <https://github.com/ianarsenault> |
+| jamesarems | <jamesarems@users.noreply.github.com> | <https://github.com/jamesarems> |
 
 ## Source Code
 
@@ -98,6 +100,9 @@ A Helm Chart to setup a generic deployment with optional service/hpa/vpa binding
 | service.basicAuth | object | `{"enabled":false,"users":""}` | Basic authentication configuration |
 | service.basicAuth.enabled | bool | `false` | Enable basic authentication |
 | service.basicAuth.users | string | `""` | htpasswd-formatted users string (bcrypt hash, e.g. "user:$2y$05$...") |
+| service.buffering.enabled | bool | `false` | Enable request buffering middleware |
+| service.buffering.maxRequestBodyBytes | int | `2097152` | Maximum request body size in bytes before the request is rejected |
+| service.buffering.memRequestBodyBytes | int | `2097152` | Request body size in bytes buffered in memory before spilling to disk |
 | service.deploy | bool | `true` | Whether to setup service bindings (note: only NodePort is supported) |
 | service.gcp.networkEndpointGroupName | string | `""` | Name of the Network Endpoint Group to bind onto |
 | service.ingress | object | `{}` | A map of ingress rules to deploy |

--- a/charts/service-deployment/templates/_helpers.tpl
+++ b/charts/service-deployment/templates/_helpers.tpl
@@ -58,6 +58,9 @@ Usage: {{ include "service.traefik.middlewares" . }}
 {{- if $.Values.service.basicAuth.enabled -}}
   {{- $middlewares = append $middlewares (printf "%s-%s-basic-auth@kubernetescrd" $.Release.Namespace (include "app.fullname" $)) -}}
 {{- end -}}
+{{- if $.Values.service.buffering.enabled -}}
+  {{- $middlewares = append $middlewares (printf "%s-%s-buffering@kubernetescrd" $.Release.Namespace (include "app.fullname" $)) -}}
+{{- end -}}
 {{- if $middlewares -}}
 {{- join ", " $middlewares | quote -}}
 {{- end -}}

--- a/charts/service-deployment/templates/buffering.yaml
+++ b/charts/service-deployment/templates/buffering.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.service.buffering.enabled .Values.service.ingress -}}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "app.fullname" . }}-buffering
+  labels:
+    {{- include "snowplow.labels" $ | nindent 4 }}
+spec:
+  buffering:
+    maxRequestBodyBytes: {{ .Values.service.buffering.maxRequestBodyBytes | int64 }}
+    memRequestBodyBytes: {{ .Values.service.buffering.memRequestBodyBytes | int64 }}
+{{- end -}}

--- a/charts/service-deployment/values.yaml
+++ b/charts/service-deployment/values.yaml
@@ -237,6 +237,14 @@ service:
     # -- htpasswd-formatted users string (bcrypt hash, e.g. "user:$2y$05$...")
     users: ""
 
+  buffering:
+    # -- Enable request buffering middleware
+    enabled: false
+    # -- Maximum request body size in bytes before the request is rejected
+    maxRequestBodyBytes: 2097152
+    # -- Request body size in bytes buffered in memory before spilling to disk
+    memRequestBodyBytes: 2097152
+
 dockerconfigjson:
   # -- Name of the secret to use for the private repository
   name: "snowplow-sd-dockerhub"


### PR DESCRIPTION
Add buffering middleware support (#354 )

---

  - Add optional Traefik request buffering middleware to service-deployment, configurable via service.buffering.enabled, service.buffering.maxRequestBodyBytes, and service.buffering.memRequestBodyBytes.
  - Middleware is only rendered when buffering is enabled and an ingress is configured, and is automatically appended to the chart's Traefik middleware chain alongside basic-auth.
  - Bump service-deployment chart version 0.41.0 → 0.42.0, update maintainers list, and regenerate README/CHANGELOG accordingly.
- Update CLAUDE.md so that maintainers are sorted by name alphabetic order